### PR TITLE
LibraryView: CoreData in LibraryView

### DIFF
--- a/Reed.xcodeproj/project.pbxproj
+++ b/Reed.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		B81C86FD250A1370000B9E5F /* LibraryViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B81C86FC250A1370000B9E5F /* LibraryViewModel.swift */; };
 		B81C86FF250A2207000B9E5F /* LibraryEntryViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B81C86FE250A2207000B9E5F /* LibraryEntryViewModel.swift */; };
+		B81C8702250A3675000B9E5F /* MockLibraryEntryData.swift in Sources */ = {isa = PBXBuildFile; fileRef = B81C8701250A3675000B9E5F /* MockLibraryEntryData.swift */; };
 		B8667F102509C745001EABD4 /* AppView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8667F0F2509C745001EABD4 /* AppView.swift */; };
 		B8667F132509CA68001EABD4 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8667F122509CA68001EABD4 /* SettingsView.swift */; };
 		B89CD68625098C0100D7D8ED /* DiscoverView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B89CD68525098C0100D7D8ED /* DiscoverView.swift */; };
@@ -51,6 +52,7 @@
 /* Begin PBXFileReference section */
 		B81C86FC250A1370000B9E5F /* LibraryViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryViewModel.swift; sourceTree = "<group>"; };
 		B81C86FE250A2207000B9E5F /* LibraryEntryViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryEntryViewModel.swift; sourceTree = "<group>"; };
+		B81C8701250A3675000B9E5F /* MockLibraryEntryData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockLibraryEntryData.swift; sourceTree = "<group>"; };
 		B8667F0F2509C745001EABD4 /* AppView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppView.swift; sourceTree = "<group>"; };
 		B8667F122509CA68001EABD4 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
 		B89CD68525098C0100D7D8ED /* DiscoverView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscoverView.swift; sourceTree = "<group>"; };
@@ -111,6 +113,14 @@
 				B81C86FE250A2207000B9E5F /* LibraryEntryViewModel.swift */,
 			);
 			path = viewmodels;
+			sourceTree = "<group>";
+		};
+		B81C8700250A365F000B9E5F /* models */ = {
+			isa = PBXGroup;
+			children = (
+				B81C8701250A3675000B9E5F /* MockLibraryEntryData.swift */,
+			);
+			path = models;
 			sourceTree = "<group>";
 		};
 		B8667F112509CA5D001EABD4 /* views */ = {
@@ -240,6 +250,7 @@
 		B8D456CD2508D349000F9E5F /* LibraryTab */ = {
 			isa = PBXGroup;
 			children = (
+				B81C8700250A365F000B9E5F /* models */,
 				B81C86FB250A005C000B9E5F /* viewmodels */,
 				B8D456D22508DCB7000F9E5F /* views */,
 			);
@@ -444,6 +455,7 @@
 				B81C86FF250A2207000B9E5F /* LibraryEntryViewModel.swift in Sources */,
 				B89CD69A2509944200D7D8ED /* MockCards.swift in Sources */,
 				B89CD6942509934700D7D8ED /* VocabularyListView.swift in Sources */,
+				B81C8702250A3675000B9E5F /* MockLibraryEntryData.swift in Sources */,
 				B8D4569C2508D1A2000F9E5F /* SceneDelegate.swift in Sources */,
 				B81C86FD250A1370000B9E5F /* LibraryViewModel.swift in Sources */,
 			);

--- a/Reed.xcodeproj/project.pbxproj
+++ b/Reed.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		B81C86FD250A1370000B9E5F /* LibraryViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B81C86FC250A1370000B9E5F /* LibraryViewModel.swift */; };
+		B81C86FF250A2207000B9E5F /* LibraryEntryViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B81C86FE250A2207000B9E5F /* LibraryEntryViewModel.swift */; };
 		B8667F102509C745001EABD4 /* AppView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8667F0F2509C745001EABD4 /* AppView.swift */; };
 		B8667F132509CA68001EABD4 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8667F122509CA68001EABD4 /* SettingsView.swift */; };
 		B89CD68625098C0100D7D8ED /* DiscoverView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B89CD68525098C0100D7D8ED /* DiscoverView.swift */; };
@@ -47,6 +49,8 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		B81C86FC250A1370000B9E5F /* LibraryViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryViewModel.swift; sourceTree = "<group>"; };
+		B81C86FE250A2207000B9E5F /* LibraryEntryViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryEntryViewModel.swift; sourceTree = "<group>"; };
 		B8667F0F2509C745001EABD4 /* AppView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppView.swift; sourceTree = "<group>"; };
 		B8667F122509CA68001EABD4 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
 		B89CD68525098C0100D7D8ED /* DiscoverView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscoverView.swift; sourceTree = "<group>"; };
@@ -100,6 +104,15 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		B81C86FB250A005C000B9E5F /* viewmodels */ = {
+			isa = PBXGroup;
+			children = (
+				B81C86FC250A1370000B9E5F /* LibraryViewModel.swift */,
+				B81C86FE250A2207000B9E5F /* LibraryEntryViewModel.swift */,
+			);
+			path = viewmodels;
+			sourceTree = "<group>";
+		};
 		B8667F112509CA5D001EABD4 /* views */ = {
 			isa = PBXGroup;
 			children = (
@@ -215,11 +228,11 @@
 		B8D456CC2508D2E3000F9E5F /* Main */ = {
 			isa = PBXGroup;
 			children = (
+				B8667F0F2509C745001EABD4 /* AppView.swift */,
 				B8D456992508D1A2000F9E5F /* AppDelegate.swift */,
 				B8D4569B2508D1A2000F9E5F /* SceneDelegate.swift */,
 				B8D456A22508D1A2000F9E5F /* Assets.xcassets */,
 				B8D4569D2508D1A2000F9E5F /* Reed.xcdatamodeld */,
-				B8667F0F2509C745001EABD4 /* AppView.swift */,
 			);
 			path = Main;
 			sourceTree = "<group>";
@@ -227,6 +240,7 @@
 		B8D456CD2508D349000F9E5F /* LibraryTab */ = {
 			isa = PBXGroup;
 			children = (
+				B81C86FB250A005C000B9E5F /* viewmodels */,
 				B8D456D22508DCB7000F9E5F /* views */,
 			);
 			path = LibraryTab;
@@ -427,9 +441,11 @@
 				B8D456A12508D1A2000F9E5F /* LibraryView.swift in Sources */,
 				B89CD6962509938C00D7D8ED /* VocabularyCardView.swift in Sources */,
 				B89CD698250993F800D7D8ED /* DefinitionModal.swift in Sources */,
+				B81C86FF250A2207000B9E5F /* LibraryEntryViewModel.swift in Sources */,
 				B89CD69A2509944200D7D8ED /* MockCards.swift in Sources */,
 				B89CD6942509934700D7D8ED /* VocabularyListView.swift in Sources */,
 				B8D4569C2508D1A2000F9E5F /* SceneDelegate.swift in Sources */,
+				B81C86FD250A1370000B9E5F /* LibraryViewModel.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Reed/LibraryTab/models/MockLibraryEntryData.swift
+++ b/Reed/LibraryTab/models/MockLibraryEntryData.swift
@@ -1,0 +1,22 @@
+//
+//  MockLibraryEntryData.swift
+//  Reed
+//
+//  Created by Roger Luo on 9/10/20.
+//  Copyright © 2020 Roger Luo. All rights reserved.
+//
+
+import Foundation
+
+class MockLibraryEntryData {
+    static let titles: [String] = [
+        "無職転生　- 異世界行ったら本気だす -",
+        "婚約破棄を狙って記憶喪失のフリをしたら、素っ気ない態度だった婚約者が「記憶を失う前の君は、俺にベタ惚れだった」という、とんでもない嘘をつき始めた",
+        "羊人間",
+    ]
+    static let authors: [String] = [
+        "理不尽な孫の手",
+        "琴子",
+        "間野　ハルヒコ"
+    ]
+}

--- a/Reed/LibraryTab/viewmodels/LibraryEntryViewModel.swift
+++ b/Reed/LibraryTab/viewmodels/LibraryEntryViewModel.swift
@@ -1,0 +1,32 @@
+//
+//  LibraryEntryViewModel.swift
+//  Reed
+//
+//  Created by Roger Luo on 9/10/20.
+//  Copyright © 2020 Roger Luo. All rights reserved.
+//
+
+import SwiftUI
+
+class LibraryEntryViewModel: ObservableObject {
+    let title: String
+    let author: String
+    
+    init(entryData: LibraryEntry) {
+        title = entryData.title ?? "unknown"
+        author = entryData.author ?? "unknown"
+    }
+}
+
+extension LibraryEntryViewModel: Hashable {
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(title)
+        hasher.combine(author)
+    }
+}
+
+extension LibraryEntryViewModel: Equatable {
+    static func == (lhs: LibraryEntryViewModel, rhs: LibraryEntryViewModel) -> Bool {
+        return lhs.title == rhs.title && lhs.author == rhs.author
+    }
+}

--- a/Reed/LibraryTab/viewmodels/LibraryViewModel.swift
+++ b/Reed/LibraryTab/viewmodels/LibraryViewModel.swift
@@ -13,6 +13,7 @@ class LibraryViewModel: ObservableObject {
     @Published var libraryEntries = [LibraryEntryViewModel]()
     
     init() {
+        insertMockCoreData()
         fetchEntries()
     }
     
@@ -25,8 +26,39 @@ class LibraryViewModel: ObservableObject {
                 LibraryEntryViewModel(entryData: $0 as! LibraryEntry)
             }
         } catch {
-            print("Fetch failed: LibraryEntry in LibraryViewModel")
+            print("Unable to fetch entity LibraryEntry in LibraryViewModel.")
             libraryEntries = []
         }
+    }
+    
+    func insertMockCoreData() {
+        if countNumCoreDataEntries() == 0 {
+            let context = (UIApplication.shared.delegate as! AppDelegate).persistentContainer.viewContext
+            let n = MockLibraryEntryData.titles.count
+            for i in 0..<n {
+                let entry = LibraryEntry(context: context)
+                entry.title = MockLibraryEntryData.titles[i]
+                entry.author = MockLibraryEntryData.authors[i]
+                do {
+                    try context.save()
+                } catch {
+                    print("Unable to save LibraryEntry entity in LibraryViewModel.")
+                }
+            }
+        }
+    }
+    
+    func countNumCoreDataEntries() -> Int {
+        let context = (UIApplication.shared.delegate as! AppDelegate).persistentContainer.viewContext
+        let fetchRequest: NSFetchRequest<LibraryEntry> = LibraryEntry.fetchRequest()
+        var numEntries = 0
+        
+        do {
+            numEntries = try context.count(for: fetchRequest)
+        } catch {
+            print("Unable to count entity LibraryEntry in LibraryViewModel.")
+        }
+        
+        return numEntries
     }
 }

--- a/Reed/LibraryTab/viewmodels/LibraryViewModel.swift
+++ b/Reed/LibraryTab/viewmodels/LibraryViewModel.swift
@@ -1,0 +1,32 @@
+//
+//  LibraryViewModel.swift
+//  Reed
+//
+//  Created by Roger Luo on 9/10/20.
+//  Copyright © 2020 Roger Luo. All rights reserved.
+//
+
+import CoreData
+import SwiftUI
+
+class LibraryViewModel: ObservableObject {
+    @Published var libraryEntries = [LibraryEntryViewModel]()
+    
+    init() {
+        fetchEntries()
+    }
+    
+    func fetchEntries() {
+        let context = (UIApplication.shared.delegate as! AppDelegate).persistentContainer.viewContext
+        let fetchRequest: NSFetchRequest<LibraryEntry> = LibraryEntry.fetchRequest()
+        do {
+            let entriesCoreData: [NSFetchRequestResult] = try context.fetch(fetchRequest)
+            libraryEntries = entriesCoreData.map {
+                LibraryEntryViewModel(entryData: $0 as! LibraryEntry)
+            }
+        } catch {
+            print("Fetch failed: LibraryEntry in LibraryViewModel")
+            libraryEntries = []
+        }
+    }
+}

--- a/Reed/LibraryTab/views/LibraryEntryView.swift
+++ b/Reed/LibraryTab/views/LibraryEntryView.swift
@@ -15,8 +15,12 @@ struct LibraryEntryView: View {
         VStack(alignment: .leading) {
             Text(entry.title)
                 .font(.headline)
+                .lineLimit(1)
+                .truncationMode(.tail)
             Text(entry.author)
                 .font(.caption)
+                .lineLimit(1)
+                .truncationMode(.tail)
         }
     }
 }

--- a/Reed/LibraryTab/views/LibraryEntryView.swift
+++ b/Reed/LibraryTab/views/LibraryEntryView.swift
@@ -9,13 +9,13 @@
 import SwiftUI
 
 struct LibraryEntryView: View {
-    var entry: LibraryEntry
+    var entry: LibraryEntryViewModel
 
     var body: some View {
         VStack(alignment: .leading) {
-            Text(entry.title ?? "unknown")
+            Text(entry.title)
                 .font(.headline)
-            Text(entry.author ?? "unknown")
+            Text(entry.author)
                 .font(.caption)
         }
     }
@@ -26,9 +26,10 @@ struct LibraryViewController_Previews: PreviewProvider {
     static var previews: some View {
         let context = (UIApplication.shared.delegate as! AppDelegate).persistentContainer.viewContext
         
-        let entry = LibraryEntry(context: context)
-        entry.title = "無職転生　- 異世界行ったら本気だす -"
-        entry.author = "理不尽な孫の手"
+        let entryData = LibraryEntry(context: context)
+        entryData.title = "無職転生　- 異世界行ったら本気だす -"
+        entryData.author = "理不尽な孫の手"
+        let entry = LibraryEntryViewModel(entryData: entryData)
         
         return LibraryEntryView(entry: entry).environment(\.managedObjectContext, context)
     }

--- a/Reed/LibraryTab/views/LibraryView.swift
+++ b/Reed/LibraryTab/views/LibraryView.swift
@@ -9,13 +9,12 @@
 import SwiftUI
 
 struct LibraryView: View {
-    @FetchRequest(entity: LibraryEntry.entity(), sortDescriptors: [])
-    var libraryEntries: FetchedResults<LibraryEntry>
+    @ObservedObject var viewModel: LibraryViewModel
     
     var body: some View {
         NavigationView {
             List {
-                ForEach(libraryEntries, id: \.self) { entry in
+                ForEach(viewModel.libraryEntries, id: \.self) { entry in
                     LibraryEntryView(entry: entry)
                 }
             }
@@ -26,7 +25,7 @@ struct LibraryView: View {
 
 struct LibraryView_Previews: PreviewProvider {
     static var previews: some View {
-        let context = (UIApplication.shared.delegate as! AppDelegate).persistentContainer.viewContext
-        return LibraryView().environment(\.managedObjectContext, context)
+        let viewModel = LibraryViewModel()
+        return LibraryView(viewModel: viewModel)
     }
 }

--- a/Reed/Main/AppView.swift
+++ b/Reed/Main/AppView.swift
@@ -12,7 +12,7 @@ struct AppView: View {
     
     var body: some View {
         TabView {
-            LibraryView()
+            LibraryView(viewModel: LibraryViewModel())
                 .tabItem {
                     Image(systemName: "book")
                     Text("Library")
@@ -41,8 +41,6 @@ struct AppView: View {
 
 struct AppView_Previews: PreviewProvider {
     static var previews: some View {
-        let context = (UIApplication.shared.delegate as! AppDelegate).persistentContainer.viewContext
-        
-        return AppView().environment(\.managedObjectContext, context)
+        return AppView()
     }
 }


### PR DESCRIPTION
Commit #1: View models for Core Data
This commit adds CoreData functionality into LibraryView. In doing so, we introduce `LibraryViewModel` and `LibraryEntryViewModel` view models to handle Core Data logic. Even though SwiftUI makes fetching super easy with the `@FetchRequest` decorator, this decorator cannot be used outside of views, meaning that it cannot be used in view models. We therefore fallback to using `NSFetchRequests` to handle our CoreData requests.

Commit #2: Adding dummy Core Data
This commit adds the functionality to put dummy `LibraryEntry` data into Core Data. Dummy entries will be useful for debugging and perhaps unit testing.