### PR TITLE
Tests: Slightly improve testing structure & performance.

### DIFF
--- a/Reed.xcodeproj/project.pbxproj
+++ b/Reed.xcodeproj/project.pbxproj
@@ -428,8 +428,8 @@
 			isa = PBXGroup;
 			children = (
 				B8D456B32508D1A2000F9E5F /* DictionaryParserTests.swift */,
-				B8939B8325152ED0000399E0 /* DictionaryParserTestUtils.swift */,
 				B8539EE42519755A000FF025 /* DictionaryStorageManagerTests.swift */,
+				B8939B8325152ED0000399E0 /* DictionaryParserTestUtils.swift */,
 			);
 			path = Dictionary;
 			sourceTree = "<group>";

--- a/ReedTests/Dictionary/DictionaryParserTests.swift
+++ b/ReedTests/Dictionary/DictionaryParserTests.swift
@@ -31,11 +31,6 @@ class DictionaryParserTest: XCTestCase {
         mockContext = mockParser.context
     }
     
-    override func tearDown() {
-        mockParser.storageManager.flushAll()
-        super.tearDown()
-    }
-    
 //    func testReadInDictionaryData() {
 //        XCTAssertNotNil(try? mockParser.readInDictionaryData())
 //    }

--- a/ReedTests/Dictionary/DictionaryStorageManagerTests.swift
+++ b/ReedTests/Dictionary/DictionaryStorageManagerTests.swift
@@ -25,7 +25,7 @@ class DictionaryStorageManagerTest: XCTestCase {
     override func setUp() {
         super.setUp()
         
-        mockContainer = createMockPersistentContainer(model: managedObjectModel)
+        mockContainer = createMockPersistentContainer(model: managedObjectModel, storeType: NSSQLiteStoreType)
         let mockStorageManager = DictionaryStorageManager(container: mockContainer)
         mockParser = DictionaryParser(storageManager: mockStorageManager)
         mockContext = mockParser.context

--- a/ReedTests/TestUtils.swift
+++ b/ReedTests/TestUtils.swift
@@ -8,20 +8,23 @@
 
 import CoreData
 
-func createMockPersistentContainer(model: NSManagedObjectModel) -> NSPersistentContainer {
+func createMockPersistentContainer(
+    model: NSManagedObjectModel,
+    storeType: String = NSInMemoryStoreType
+) -> NSPersistentContainer {
     
     let container = NSPersistentContainer(
         name: "mockContainer",
         managedObjectModel: model
     )
     let description = NSPersistentStoreDescription()
-    description.type = NSSQLiteStoreType
+    description.type = storeType
     description.shouldAddStoreAsynchronously = false
     
     container.persistentStoreDescriptions = [description]
     container.loadPersistentStores { (description, error) in
         // Check if the data store is in memory
-        precondition( description.type == NSSQLiteStoreType )
+        precondition(description.type == storeType)
                                     
         // Check if creating container wrong
         if let error = error {


### PR DESCRIPTION
This commit slightly improves the testing structure by allowing the tester to choose the type of CoreData store they want to use. In most cases, using NSInMemoryStoreType would be faster (and easier!), but some tests require the NSSqliteStoreType.