### PR TITLE
Dictionary: Fetching entries with readings and terms.

### DIFF
--- a/Reed.xcodeproj/project.pbxproj
+++ b/Reed.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		B81C86FF250A2207000B9E5F /* LibraryEntryViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B81C86FE250A2207000B9E5F /* LibraryEntryViewModel.swift */; };
 		B81C8702250A3675000B9E5F /* MockLibraryEntryData.swift in Sources */ = {isa = PBXBuildFile; fileRef = B81C8701250A3675000B9E5F /* MockLibraryEntryData.swift */; };
 		B8462309250AF5A3002358A0 /* DictionaryParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8462308250AF5A3002358A0 /* DictionaryParser.swift */; };
+		B846482F2526CB5000D5A76D /* DictionaryFetcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B846482E2526CB5000D5A76D /* DictionaryFetcherTests.swift */; };
 		B8539EE52519755A000FF025 /* DictionaryStorageManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8539EE42519755A000FF025 /* DictionaryStorageManagerTests.swift */; };
 		B860B7122518207900F48FBE /* JMdict_e.json.gz in Resources */ = {isa = PBXBuildFile; fileRef = B860B7112518207800F48FBE /* JMdict_e.json.gz */; };
 		B8667F102509C745001EABD4 /* AppView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8667F0F2509C745001EABD4 /* AppView.swift */; };
@@ -34,6 +35,9 @@
 		B89CD6962509938C00D7D8ED /* VocabularyCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B89CD6952509938C00D7D8ED /* VocabularyCardView.swift */; };
 		B89CD698250993F800D7D8ED /* DefinitionModal.swift in Sources */ = {isa = PBXBuildFile; fileRef = B89CD697250993F800D7D8ED /* DefinitionModal.swift */; };
 		B89CD69A2509944200D7D8ED /* MockCards.swift in Sources */ = {isa = PBXBuildFile; fileRef = B89CD6992509944200D7D8ED /* MockCards.swift */; };
+		B8A2617F25268B5C00A2FBFD /* Utils.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8A2617E25268B5C00A2FBFD /* Utils.swift */; };
+		B8A5E50E2527BACE003BCF07 /* UtilsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8A5E50D2527BACE003BCF07 /* UtilsTests.swift */; };
+		B8B8F9912526C10400D6DF8B /* DictionaryFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8B8F9902526C10400D6DF8B /* DictionaryFetcher.swift */; };
 		B8D4569A2508D1A2000F9E5F /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8D456992508D1A2000F9E5F /* AppDelegate.swift */; };
 		B8D4569C2508D1A2000F9E5F /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8D4569B2508D1A2000F9E5F /* SceneDelegate.swift */; };
 		B8D4569F2508D1A2000F9E5F /* Reed.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = B8D4569D2508D1A2000F9E5F /* Reed.xcdatamodeld */; };
@@ -81,6 +85,7 @@
 		B81C86FE250A2207000B9E5F /* LibraryEntryViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryEntryViewModel.swift; sourceTree = "<group>"; };
 		B81C8701250A3675000B9E5F /* MockLibraryEntryData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockLibraryEntryData.swift; sourceTree = "<group>"; };
 		B8462308250AF5A3002358A0 /* DictionaryParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictionaryParser.swift; sourceTree = "<group>"; };
+		B846482E2526CB5000D5A76D /* DictionaryFetcherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictionaryFetcherTests.swift; sourceTree = "<group>"; };
 		B8539EE42519755A000FF025 /* DictionaryStorageManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictionaryStorageManagerTests.swift; sourceTree = "<group>"; };
 		B860B7112518207800F48FBE /* JMdict_e.json.gz */ = {isa = PBXFileReference; lastKnownFileType = archive.gzip; path = JMdict_e.json.gz; sourceTree = "<group>"; };
 		B8667F0F2509C745001EABD4 /* AppView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppView.swift; sourceTree = "<group>"; };
@@ -100,6 +105,9 @@
 		B89CD6952509938C00D7D8ED /* VocabularyCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VocabularyCardView.swift; sourceTree = "<group>"; };
 		B89CD697250993F800D7D8ED /* DefinitionModal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefinitionModal.swift; sourceTree = "<group>"; };
 		B89CD6992509944200D7D8ED /* MockCards.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockCards.swift; sourceTree = "<group>"; };
+		B8A2617E25268B5C00A2FBFD /* Utils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Utils.swift; sourceTree = "<group>"; };
+		B8A5E50D2527BACE003BCF07 /* UtilsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UtilsTests.swift; sourceTree = "<group>"; };
+		B8B8F9902526C10400D6DF8B /* DictionaryFetcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictionaryFetcher.swift; sourceTree = "<group>"; };
 		B8D456962508D1A2000F9E5F /* Reed.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Reed.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		B8D456992508D1A2000F9E5F /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		B8D4569B2508D1A2000F9E5F /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -197,20 +205,13 @@
 		B8462307250AF4E4002358A0 /* Dictionary */ = {
 			isa = PBXGroup;
 			children = (
-				B860B7112518207800F48FBE /* JMdict_e.json.gz */,
-				B8F5C209250EDDB2000810F8 /* DictionaryEntry+CoreDataClass.swift */,
-				B8F5C20A250EDDB2000810F8 /* DictionaryEntry+CoreDataProperties.swift */,
-				B8F5C213250EDEEB000810F8 /* DictionaryTerm+CoreDataClass.swift */,
-				B8F5C214250EDEEB000810F8 /* DictionaryTerm+CoreDataProperties.swift */,
-				B8F5C20B250EDDB2000810F8 /* DictionaryReading+CoreDataClass.swift */,
-				B8F5C20C250EDDB2000810F8 /* DictionaryReading+CoreDataProperties.swift */,
-				B8F5C211250EDEEB000810F8 /* DictionaryDefinition+CoreDataClass.swift */,
-				B8F5C212250EDEEB000810F8 /* DictionaryDefinition+CoreDataProperties.swift */,
-				B87D30752516C537002E25FF /* DictionaryLanguageSource+CoreDataClass.swift */,
-				B87D30762516C537002E25FF /* DictionaryLanguageSource+CoreDataProperties.swift */,
+				B8B8F9952526C28E00D6DF8B /* CoreData */,
+				B8B8F9902526C10400D6DF8B /* DictionaryFetcher.swift */,
 				B8462308250AF5A3002358A0 /* DictionaryParser.swift */,
 				B89810F7250F17210059F71F /* DictionaryStorageManager.swift */,
 				B8093DD5251A988200D95DCF /* NotificationName+DictionaryParser.swift */,
+				B8A2617E25268B5C00A2FBFD /* Utils.swift */,
+				B860B7112518207800F48FBE /* JMdict_e.json.gz */,
 			);
 			path = Dictionary;
 			sourceTree = "<group>";
@@ -281,6 +282,23 @@
 				B89CD6952509938C00D7D8ED /* VocabularyCardView.swift */,
 			);
 			path = views;
+			sourceTree = "<group>";
+		};
+		B8B8F9952526C28E00D6DF8B /* CoreData */ = {
+			isa = PBXGroup;
+			children = (
+				B8F5C209250EDDB2000810F8 /* DictionaryEntry+CoreDataClass.swift */,
+				B8F5C20A250EDDB2000810F8 /* DictionaryEntry+CoreDataProperties.swift */,
+				B8F5C213250EDEEB000810F8 /* DictionaryTerm+CoreDataClass.swift */,
+				B8F5C214250EDEEB000810F8 /* DictionaryTerm+CoreDataProperties.swift */,
+				B8F5C20B250EDDB2000810F8 /* DictionaryReading+CoreDataClass.swift */,
+				B8F5C20C250EDDB2000810F8 /* DictionaryReading+CoreDataProperties.swift */,
+				B8F5C211250EDEEB000810F8 /* DictionaryDefinition+CoreDataClass.swift */,
+				B8F5C212250EDEEB000810F8 /* DictionaryDefinition+CoreDataProperties.swift */,
+				B87D30752516C537002E25FF /* DictionaryLanguageSource+CoreDataClass.swift */,
+				B87D30762516C537002E25FF /* DictionaryLanguageSource+CoreDataProperties.swift */,
+			);
+			path = CoreData;
 			sourceTree = "<group>";
 		};
 		B8D4568D2508D1A2000F9E5F = {
@@ -430,6 +448,8 @@
 				B8D456B32508D1A2000F9E5F /* DictionaryParserTests.swift */,
 				B8539EE42519755A000FF025 /* DictionaryStorageManagerTests.swift */,
 				B8939B8325152ED0000399E0 /* DictionaryParserTestUtils.swift */,
+				B846482E2526CB5000D5A76D /* DictionaryFetcherTests.swift */,
+				B8A5E50D2527BACE003BCF07 /* UtilsTests.swift */,
 			);
 			path = Dictionary;
 			sourceTree = "<group>";
@@ -625,10 +645,12 @@
 				B8D456D82508DD46000F9E5F /* MockBooks.swift in Sources */,
 				B8D4569A2508D1A2000F9E5F /* AppDelegate.swift in Sources */,
 				B8F5C210250EDDB2000810F8 /* DictionaryReading+CoreDataProperties.swift in Sources */,
+				B8A2617F25268B5C00A2FBFD /* Utils.swift in Sources */,
 				B880D139251810F20097AF8D /* SplashViewModel.swift in Sources */,
 				B8D456D62508DD24000F9E5F /* LibraryEntryView.swift in Sources */,
 				B898110B250F81600059F71F /* NSManagedObject+Init.swift in Sources */,
 				B8D4569F2508D1A2000F9E5F /* Reed.xcdatamodeld in Sources */,
+				B8B8F9912526C10400D6DF8B /* DictionaryFetcher.swift in Sources */,
 				B89CD68625098C0100D7D8ED /* DiscoverView.swift in Sources */,
 				B8667F102509C745001EABD4 /* AppView.swift in Sources */,
 				B8F5C218250EDEEB000810F8 /* DictionaryTerm+CoreDataProperties.swift in Sources */,
@@ -656,7 +678,9 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				B8A5E50E2527BACE003BCF07 /* UtilsTests.swift in Sources */,
 				B8D456B42508D1A2000F9E5F /* DictionaryParserTests.swift in Sources */,
+				B846482F2526CB5000D5A76D /* DictionaryFetcherTests.swift in Sources */,
 				B8981108250F6D140059F71F /* Reed.xcdatamodeld in Sources */,
 				B8939B8425152ED0000399E0 /* DictionaryParserTestUtils.swift in Sources */,
 				B89810FA250F504E0059F71F /* TestUtils.swift in Sources */,

--- a/Reed/Dictionary/DictionaryFetcher.swift
+++ b/Reed/Dictionary/DictionaryFetcher.swift
@@ -1,0 +1,47 @@
+//
+//  DictionaryFetcher.swift
+//  Reed
+//
+//  Created by Roger Luo on 10/1/20.
+//  Copyright © 2020 Roger Luo. All rights reserved.
+//
+
+import CoreData
+import SwiftUI
+
+
+class DictionaryFetcher {
+    
+    let persistentContainer: NSPersistentContainer
+    
+    init(container: NSPersistentContainer) {
+        self.persistentContainer = container
+    }
+    
+    convenience init() {
+        guard let appDelegate = UIApplication.shared.delegate as? AppDelegate else {
+            fatalError("Could not get shared app delegate.")
+        }
+        self.init(container: appDelegate.persistentContainer)
+    }
+    
+    func fetchEntries(of key: String) -> [DictionaryEntry] {
+        return isKana(key)
+            ? fetchReadings(with: key).map { $0.entry }
+            : fetchTerms(with: key).map { $0.entry }
+    }
+
+    func fetchReadings(with reading: String) -> [DictionaryReading] {
+        let fetchRequest: NSFetchRequest<DictionaryReading> = DictionaryReading.fetchRequest()
+        fetchRequest.predicate = NSPredicate(format: "readingReading == %@", reading)
+        return (try? persistentContainer.viewContext.fetch(fetchRequest)) ?? []
+    }
+
+    func fetchTerms(with term: String) -> [DictionaryTerm] {
+        let fetchRequest: NSFetchRequest<DictionaryTerm> = DictionaryTerm.fetchRequest()
+        fetchRequest.predicate = NSPredicate(format: "termTerm == %@", term)
+        print("swag")
+        return (try? persistentContainer.viewContext.fetch(fetchRequest)) ?? []
+    }
+    
+}

--- a/Reed/Dictionary/DictionaryStorageManager.swift
+++ b/Reed/Dictionary/DictionaryStorageManager.swift
@@ -54,25 +54,3 @@ class DictionaryStorageManager {
         }
     }
 }
-
-/// Handles the retrieval of Dictionary objects.
-extension DictionaryStorageManager {
-    
-    func fetchEntries(key: String, isKana: Bool) -> [DictionaryEntry] {
-        if isKana {
-            return fetchReadings().map { $0.entry }
-        }
-        return fetchTerms().map { $0.entry }
-    }
-    
-    func fetchReadings() -> [DictionaryReading] {
-        let fetchRequest: NSFetchRequest<DictionaryReading> = DictionaryReading.fetchRequest()
-        return (try? backgroundContext.fetch(fetchRequest)) ?? []
-    }
-    
-    func fetchTerms() -> [DictionaryTerm] {
-        let fetchRequest: NSFetchRequest<DictionaryTerm> = DictionaryTerm.fetchRequest()
-        return (try? backgroundContext.fetch(fetchRequest)) ?? []
-    }
-    
-}

--- a/Reed/Dictionary/Utils.swift
+++ b/Reed/Dictionary/Utils.swift
@@ -1,0 +1,26 @@
+//
+//  Utils.swift
+//  Reed
+//
+//  Created by Roger Luo on 10/1/20.
+//  Copyright © 2020 Roger Luo. All rights reserved.
+//
+
+import CoreData
+
+func isKana(_ string: String) -> Bool {
+    for char in string {
+        if !isKana(char) {
+            return false
+        }
+    }
+    return true
+}
+
+func isKana(_ char: Character) -> Bool {
+    let charScalar = char.unicodeScalars.map { $0.value }.reduce(0, +)
+    
+    // https://www.key-shortcut.com/en/writing-systems/ひらがな-japanese
+    return charScalar >= 0x3040 && charScalar <= 0x309f
+        || charScalar >= 0x30a0 && charScalar <= 0x30ff
+}

--- a/ReedTests/Dictionary/DictionaryFetcherTests.swift
+++ b/ReedTests/Dictionary/DictionaryFetcherTests.swift
@@ -1,0 +1,184 @@
+//
+//  DictionaryFetcherTests.swift
+//  ReedTests
+//
+//  Created by Roger Luo on 10/1/20.
+//  Copyright © 2020 Roger Luo. All rights reserved.
+//
+
+import CoreData
+import XCTest
+@testable import Reed
+
+
+class DictionaryFetcherTests: XCTestCase {
+    
+    lazy var managedObjectModel: NSManagedObjectModel = {
+        let managedObjectModel = NSManagedObjectModel.mergedModel(from: [Bundle(for: type(of: self))])!
+        return managedObjectModel
+    }()
+    
+    var mockContext: NSManagedObjectContext!
+    var mockContainer: NSPersistentContainer!
+    var mockParser: DictionaryParser!
+    var mockFetcher: DictionaryFetcher!
+    
+    override func setUp() {
+        super.setUp()
+        
+        mockContainer = createMockPersistentContainer(model: managedObjectModel)
+        let mockStorageManager = DictionaryStorageManager(container: mockContainer)
+        mockParser = DictionaryParser(storageManager: mockStorageManager)
+        mockContext = mockParser.context
+        mockFetcher = DictionaryFetcher(container: mockContainer)
+    }
+
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+    
+    func testFetchReadings() {
+        let testData = formatTestData(
+            """
+            [
+                {
+                    "ent_seq": [
+                        "1"
+                    ],
+                    "r_ele": [
+                        {
+                            "reb": [
+                                "あ"
+                            ]
+                        }
+                    ],
+                    "sense": [
+                        {
+                            "gloss": [
+                                "test"
+                            ]
+                        }
+                    ]
+                },
+            ]
+            """
+        )
+        
+        let expected = ExpectedEntry(
+            id: 1,
+            readings: [
+                ExpectedReading(reading: "あ")
+            ],
+            definitions: [
+                ExpectedDefinition(
+                    glosses: ["test"]
+                )
+            ]
+        )
+        
+        mockParser.parseAndLoad(dictionaryData: testData)
+        let res = mockFetcher.fetchEntries(of: "あ")
+        XCTAssertEqual(res.count, 1)
+        validateDictionaryEntry(created: res[0], expected: expected)
+    }
+    
+    func testFetchTerms() {
+        let testData = formatTestData(
+            """
+            [
+                {
+                    "ent_seq": [
+                        "1"
+                    ],
+                    "k_ele": [
+                        {
+                            "keb": [
+                                "阿"
+                            ]
+                        }
+                    ],
+                    "r_ele": [
+                        {
+                            "reb": [
+                                "あ"
+                            ]
+                        }
+                    ],
+                    "sense": [
+                        {
+                            "gloss": [
+                                "test"
+                            ]
+                        }
+                    ]
+                },
+            ]
+            """
+        )
+        
+        let expected = ExpectedEntry(
+            id: 1,
+            terms: [
+                ExpectedTerm(term: "阿")
+            ],
+            readings: [
+                ExpectedReading(
+                    reading: "あ",
+                    terms: ["阿"]
+                ),
+            ],
+            definitions: [
+                ExpectedDefinition(
+                    glosses: ["test"]
+                )
+            ]
+        )
+        
+        mockParser.parseAndLoad(dictionaryData: testData)
+        let res = mockFetcher.fetchEntries(of: "阿")
+        XCTAssertEqual(res.count, 1)
+        validateDictionaryEntry(created: res[0], expected: expected)
+    }
+
+    func testFetchEmptyResults() {
+        let testData = formatTestData(
+            """
+            [
+                {
+                    "ent_seq": [
+                        "1"
+                    ],
+                    "k_ele": [
+                        {
+                            "keb": [
+                                "阿"
+                            ]
+                        }
+                    ],
+                    "r_ele": [
+                        {
+                            "reb": [
+                                "あ"
+                            ]
+                        }
+                    ],
+                    "sense": [
+                        {
+                            "gloss": [
+                                "test"
+                            ]
+                        }
+                    ]
+                },
+            ]
+            """
+        )
+        
+        mockParser.parseAndLoad(dictionaryData: testData)
+        var res = mockFetcher.fetchEntries(of: "お")
+        XCTAssertEqual(res.count, 0)
+        
+        res = mockFetcher.fetchEntries(of: "御")
+        XCTAssertEqual(res.count, 0)
+    }
+}

--- a/ReedTests/Dictionary/UtilsTests.swift
+++ b/ReedTests/Dictionary/UtilsTests.swift
@@ -1,0 +1,37 @@
+//
+//  UtilsTests.swift
+//  ReedTests
+//
+//  Created by Roger Luo on 10/2/20.
+//  Copyright © 2020 Roger Luo. All rights reserved.
+//
+
+import XCTest
+@testable import Reed
+
+
+class UtilsTests: XCTestCase {
+
+    func testIsKana() {
+        let trueInputs = [
+            "あ",
+            "あお",
+            "アオ",
+        ]
+        
+        let falseInputs = [
+            "蒼",
+            "蒼天",
+            "ABC"
+        ]
+        
+        for input in trueInputs {
+            XCTAssertTrue(isKana(input))
+        }
+        
+        for input in falseInputs {
+            XCTAssertFalse(isKana(input))
+        }
+    }
+
+}


### PR DESCRIPTION
This commit adds a new class, `DictionaryFetcher`, which enables fetching entries given a reading or term. The commit also introduces a utility function to determine whether some input is a kana character.

In `Dictionary/DictionaryFetcher.swift`:
- `fetchReadings` takes an input string of only kana characters and retrieves all DictionaryReadings whose `readingReading` attribute is the input.
- `fetchTerms` takes an input string that includes at least one non-kana character and retrieves all DictionaryTerms whose `termTerm` attribute is the input.
- `fetchEntries` is a convenience method that takes an input string and calls either `fetchReadings` or `fetchTerms` depending on the contents of the input. It returns the `DictionaryEntry` objects that own each `DictionaryTerm` or `DictionaryReading` in the output array of `fetchReadings` or `fetchTerms`.

Currently, the fetch will block the main thread. If this block ends up causing the UI to lag, I will implement an asynchronous fetch solution.