### PR TITLE
Reader: Implemented page flipping and word tapping

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -1,8 +1,8 @@
 target 'Reed' do
   pod 'GzipSwift'
   pod 'SwiftyJSON', '~> 4.0'
-
+  pod 'SwiftUIPager'
   target 'ReedTests' do
     inherit! :search_paths
   end
-end
+end 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,20 +1,24 @@
 PODS:
   - GzipSwift (5.1.1)
+  - SwiftUIPager (1.11.0)
   - SwiftyJSON (4.3.0)
 
 DEPENDENCIES:
   - GzipSwift
+  - SwiftUIPager
   - SwiftyJSON (~> 4.0)
 
 SPEC REPOS:
   trunk:
     - GzipSwift
+    - SwiftUIPager
     - SwiftyJSON
 
 SPEC CHECKSUMS:
   GzipSwift: 893f3e48e597a1a4f62fafcb6514220fcf8287fa
+  SwiftUIPager: c4a891a61efc2b3bba53ec359d1470e85f064a1d
   SwiftyJSON: 6faa0040f8b59dead0ee07436cbf76b73c08fd08
 
-PODFILE CHECKSUM: f7f3b2f269c1dc22aa6fd32024240090997529ed
+PODFILE CHECKSUM: 6ae9aaf32b3fc760bfc325e85895e1433c266532
 
-COCOAPODS: 1.9.3
+COCOAPODS: 1.9.1

--- a/Reed.xcodeproj/project.pbxproj
+++ b/Reed.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		373DE8EC873977020586BA5D /* libPods-Reed.a in Frameworks */ = {isa = PBXBuildFile; fileRef = DB226BA52A6687FA59B7D4F0 /* libPods-Reed.a */; };
+		6D1A3A6D250DFD5300D389B1 /* ReaderViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D1A3A6C250DFD5300D389B1 /* ReaderViewModel.swift */; };
 		A1D4D71735522B095DE86972 /* libPods-ReedTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = CB34B8D1D66FEC309309B5A6 /* libPods-ReedTests.a */; };
 		B8093DD6251A988200D95DCF /* NotificationName+DictionaryParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8093DD5251A988200D95DCF /* NotificationName+DictionaryParser.swift */; };
 		B81C86FD250A1370000B9E5F /* LibraryViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B81C86FC250A1370000B9E5F /* LibraryViewModel.swift */; };
@@ -80,6 +81,7 @@
 		05F6AF7D4822634DEDD39684 /* Pods-Reed.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Reed.release.xcconfig"; path = "Target Support Files/Pods-Reed/Pods-Reed.release.xcconfig"; sourceTree = "<group>"; };
 		09D60999940D335A7D74D917 /* Pods-ReedTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ReedTests.debug.xcconfig"; path = "Target Support Files/Pods-ReedTests/Pods-ReedTests.debug.xcconfig"; sourceTree = "<group>"; };
 		4C9134A1E97C7A555EA7B8DB /* Pods-ReedTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ReedTests.release.xcconfig"; path = "Target Support Files/Pods-ReedTests/Pods-ReedTests.release.xcconfig"; sourceTree = "<group>"; };
+		6D1A3A6C250DFD5300D389B1 /* ReaderViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ReaderViewModel.swift; path = ../../../../../Documents/ReaderViewModel.swift; sourceTree = "<group>"; };
 		B8093DD5251A988200D95DCF /* NotificationName+DictionaryParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NotificationName+DictionaryParser.swift"; sourceTree = "<group>"; };
 		B81C86FC250A1370000B9E5F /* LibraryViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryViewModel.swift; sourceTree = "<group>"; };
 		B81C86FE250A2207000B9E5F /* LibraryEntryViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryEntryViewModel.swift; sourceTree = "<group>"; };
@@ -172,6 +174,14 @@
 				CB34B8D1D66FEC309309B5A6 /* libPods-ReedTests.a */,
 			);
 			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		6D1A3A69250DFCC200D389B1 /* viewmodels */ = {
+			isa = PBXGroup;
+			children = (
+				6D1A3A6C250DFD5300D389B1 /* ReaderViewModel.swift */,
+			);
+			path = viewmodels;
 			sourceTree = "<group>";
 		};
 		AF0496628FC517FF3A2B0A80 /* Pods */ = {
@@ -394,6 +404,7 @@
 			isa = PBXGroup;
 			children = (
 				B89CD68725098FD600D7D8ED /* models */,
+				6D1A3A69250DFCC200D389B1 /* viewmodels */,
 				B89CD68C2509927C00D7D8ED /* views */,
 			);
 			path = Reader;
@@ -651,6 +662,7 @@
 				B898110B250F81600059F71F /* NSManagedObject+Init.swift in Sources */,
 				B8D4569F2508D1A2000F9E5F /* Reed.xcdatamodeld in Sources */,
 				B8B8F9912526C10400D6DF8B /* DictionaryFetcher.swift in Sources */,
+				6D1A3A6D250DFD5300D389B1 /* ReaderViewModel.swift in Sources */,
 				B89CD68625098C0100D7D8ED /* DiscoverView.swift in Sources */,
 				B8667F102509C745001EABD4 /* AppView.swift in Sources */,
 				B8F5C218250EDEEB000810F8 /* DictionaryTerm+CoreDataProperties.swift in Sources */,
@@ -835,6 +847,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_ASSET_PATHS = "\"Reed/Preview Content\"";
+				DEVELOPMENT_TEAM = "";
 				ENABLE_PREVIEWS = YES;
 				INFOPLIST_FILE = Reed/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -855,6 +868,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_ASSET_PATHS = "\"Reed/Preview Content\"";
+				DEVELOPMENT_TEAM = "";
 				ENABLE_PREVIEWS = YES;
 				INFOPLIST_FILE = Reed/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (

--- a/Reed/LibraryTab/viewmodels/LibraryEntryViewModel.swift
+++ b/Reed/LibraryTab/viewmodels/LibraryEntryViewModel.swift
@@ -8,6 +8,7 @@
 
 import SwiftUI
 
+
 class LibraryEntryViewModel: ObservableObject {
     let title: String
     let author: String

--- a/Reed/LibraryTab/viewmodels/LibraryViewModel.swift
+++ b/Reed/LibraryTab/viewmodels/LibraryViewModel.swift
@@ -9,6 +9,7 @@
 import CoreData
 import SwiftUI
 
+
 class LibraryViewModel: ObservableObject {
     @Published var libraryEntries = [LibraryEntryViewModel]()
     
@@ -60,5 +61,11 @@ class LibraryViewModel: ObservableObject {
         }
         
         return numEntries
+    }
+}
+
+struct LibraryViewModel_Previews: PreviewProvider {
+    static var previews: some View {
+        /*@START_MENU_TOKEN@*/Text("Hello, World!")/*@END_MENU_TOKEN@*/
     }
 }

--- a/Reed/Reader/views/DefinitionModal.swift
+++ b/Reed/Reader/views/DefinitionModal.swift
@@ -8,6 +8,7 @@
 
 import SwiftUI
 
+
 struct DefinitionModal: View {
     var body: some View {
         Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)

--- a/Reed/Reader/views/ReaderView.swift
+++ b/Reed/Reader/views/ReaderView.swift
@@ -7,15 +7,73 @@
 //
 
 import SwiftUI
+import SwiftUIPager
+
 
 struct ReaderView: View {
+    @ObservedObject var viewModel: ReaderViewModel
+    @State var page: Int = 0
     var body: some View {
-        Text("Reader View")
+        Pager(page: $page,
+              data: viewModel.items,
+              id: \.self,
+              content: { text in
+                VStack(alignment: /*@START_MENU_TOKEN@*/.center/*@END_MENU_TOKEN@*/, spacing: /*@START_MENU_TOKEN@*/nil/*@END_MENU_TOKEN@*/, content: {
+                        TextView(text: text)
+                        Text("\(page + 1)")
+                })
+        })
+            .alignment(.start)
+            .preferredItemSize(CGSize(width: UIScreen.main.bounds.width, height: UIScreen.main.bounds.height))
+     }
+}
+
+struct TextView: UIViewRepresentable {
+    var text: String!
+    
+    func makeUIView(context: UIViewRepresentableContext<TextView>) -> UIView {
+        let textView = UITextView()
+        textView.text = text
+        textView.font = .systemFont(ofSize: 18)
+        textView.addGestureRecognizer(UITapGestureRecognizer(target: context.coordinator, action: #selector(Coordinator.wordTapped(gesture:))))
+        return textView
+    }
+
+    class Coordinator: NSObject {
+        var tappedRange: UITextRange!
+        var selectedRange: NSRange!
+        
+        @objc func wordTapped(gesture: UITapGestureRecognizer) {
+            let textView = gesture.view as! UITextView
+            let location = gesture.location(in: textView)
+            let position = CGPoint(x: location.x, y: location.y)
+            let tapPosition = textView.closestPosition(to: position)
+            tappedRange = textView.tokenizer.rangeEnclosingPosition(tapPosition!, with: UITextGranularity.word, inDirection: UITextDirection(rawValue: 1))
+            if let tappedRange = tappedRange {
+                if let _ = textView.text(in: tappedRange) {
+                    let locInt = textView.offset(from: textView.beginningOfDocument, to: tappedRange.start)
+                    let length = textView.offset(from: tappedRange.start, to: tappedRange.end)
+                    if selectedRange != nil {
+                        textView.textStorage.addAttribute(NSAttributedString.Key.backgroundColor, value: UIColor.clear, range: selectedRange!)
+                    }
+                    selectedRange = NSRange(location: locInt, length: length)
+                    textView.textStorage.addAttribute(NSAttributedString.Key.backgroundColor, value: UIColor.lightGray, range: selectedRange!)
+                }
+            }
+        }
+    }
+
+    func makeCoordinator() -> TextView.Coordinator {
+        return Coordinator()
+    }
+
+    func updateUIView(_ uiView: UIView,
+                       context: UIViewRepresentableContext<TextView>) {
     }
 }
 
 struct ReaderView_Previews: PreviewProvider {
     static var previews: some View {
-        ReaderView()
+        ReaderView(viewModel: ReaderViewModel())
     }
 }

--- a/ReedTests/Dictionary/DictionaryParserTests.swift
+++ b/ReedTests/Dictionary/DictionaryParserTests.swift
@@ -31,9 +31,9 @@ class DictionaryParserTest: XCTestCase {
         mockContext = mockParser.context
     }
     
-//    func testReadInDictionaryData() {
-//        XCTAssertNotNil(try? mockParser.readInDictionaryData())
-//    }
+    func testReadInDictionaryData() {
+        XCTAssertNotNil(try? mockParser.readInDictionaryData())
+    }
     
     /// Test most basic entry with one <reb> and one <sense> tag.
     func testBasicEntry() {


### PR DESCRIPTION
This commit uses SwiftUIPager to implement pagination. In order to accurately paginate according to different screen sizes and text fonts, we borrow UITextView from UIKit, which helps us calculate the amount of text that fits into the frame. This commit also implements word tapping. We used UIViewRepresentable to use UITextView's functionality that allows us to get the location of a tap and its corresponding word.