### PR TITLE
LibraryTab: Small code cleanups and navbar changes.

### DIFF
--- a/Reed/LibraryTab/viewmodels/LibraryEntryViewModel.swift
+++ b/Reed/LibraryTab/viewmodels/LibraryEntryViewModel.swift
@@ -8,7 +8,6 @@
 
 import SwiftUI
 
-
 class LibraryEntryViewModel: ObservableObject {
     let title: String
     let author: String
@@ -19,14 +18,12 @@ class LibraryEntryViewModel: ObservableObject {
     }
 }
 
-extension LibraryEntryViewModel: Hashable {
+extension LibraryEntryViewModel: Hashable, Equatable {
     func hash(into hasher: inout Hasher) {
         hasher.combine(title)
         hasher.combine(author)
     }
-}
-
-extension LibraryEntryViewModel: Equatable {
+    
     static func == (lhs: LibraryEntryViewModel, rhs: LibraryEntryViewModel) -> Bool {
         return lhs.title == rhs.title && lhs.author == rhs.author
     }

--- a/Reed/LibraryTab/viewmodels/LibraryViewModel.swift
+++ b/Reed/LibraryTab/viewmodels/LibraryViewModel.swift
@@ -9,7 +9,6 @@
 import CoreData
 import SwiftUI
 
-
 class LibraryViewModel: ObservableObject {
     @Published var libraryEntries = [LibraryEntryViewModel]()
     
@@ -61,11 +60,5 @@ class LibraryViewModel: ObservableObject {
         }
         
         return numEntries
-    }
-}
-
-struct LibraryViewModel_Previews: PreviewProvider {
-    static var previews: some View {
-        /*@START_MENU_TOKEN@*/Text("Hello, World!")/*@END_MENU_TOKEN@*/
     }
 }

--- a/Reed/LibraryTab/views/LibraryView.swift
+++ b/Reed/LibraryTab/views/LibraryView.swift
@@ -14,11 +14,11 @@ struct LibraryView: View {
     var body: some View {
         NavigationView {
             List {
-                ForEach(viewModel.libraryEntries, id: \.self) { entry in
-                    LibraryEntryView(entry: entry)
+                ForEach(viewModel.libraryEntries, id: \.self) {
+                    LibraryEntryView(entry: $0)
                 }
             }
-            .navigationBarTitle("Library", displayMode: .inline)
+            .navigationBarTitle("Library")
         }
     }
 }


### PR DESCRIPTION
This commit deletes the preview for the LibraryViewModel, combines the two LibraryEntryViewModel extensions because they are related, and changes the navbar style to use the default in order to match the Discover View.

<Img src="https://user-images.githubusercontent.com/29548429/97005357-2d9ffc00-14f3-11eb-85f9-fd5e08e1a44e.png" width="50%" />
