### PR TITLE
Discover/SearchResults: Data loading and infinite scroll

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -3,7 +3,7 @@ PODS:
   - SwiftSoup (2.3.2)
   - SwiftUIPager (1.12.0)
   - SwiftyJSON (5.0.0)
-  - SwiftyNarou (1.1.6):
+  - SwiftyNarou (1.1.7):
     - GzipSwift
     - SwiftSoup
     - SwiftyJSON
@@ -27,8 +27,8 @@ SPEC CHECKSUMS:
   SwiftSoup: f97bc4e988c7729d6457f9642f974c617a6e2510
   SwiftUIPager: 84ce7c56d42a70a8c1337de14207ab5ff11dc0a9
   SwiftyJSON: 36413e04c44ee145039d332b4f4e2d3e8d6c4db7
-  SwiftyNarou: cada7701b47f61eb308e22b5ecd7261990db09b8
+  SwiftyNarou: 06dee2ab885c978a8c7ce63aa71b3c5cbd8eae6a
 
 PODFILE CHECKSUM: 65a051bb19988195c9d1581d65c7c8a1679e01a5
 
-COCOAPODS: 1.9.3
+COCOAPODS: 1.10.0

--- a/Reed.xcodeproj/project.pbxproj
+++ b/Reed.xcodeproj/project.pbxproj
@@ -11,7 +11,8 @@
 		6DCF77DB252DB19B00CB3C5D /* ReaderViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DCF77DA252DB19B00CB3C5D /* ReaderViewModel.swift */; };
 		A1D4D71735522B095DE86972 /* libPods-ReedTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = CB34B8D1D66FEC309309B5A6 /* libPods-ReedTests.a */; };
 		B8093DD6251A988200D95DCF /* NotificationName+DictionaryParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8093DD5251A988200D95DCF /* NotificationName+DictionaryParser.swift */; };
-		B80CBD272542887700C807CD /* TrendingListItemViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B80CBD262542887700C807CD /* TrendingListItemViewModel.swift */; };
+		B80CBD272542887700C807CD /* DiscoverListItemViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B80CBD262542887700C807CD /* DiscoverListItemViewModel.swift */; };
+		B80E0E6B25497E13009B0EE8 /* SearchResults.swift in Sources */ = {isa = PBXBuildFile; fileRef = B80E0E6A25497E13009B0EE8 /* SearchResults.swift */; };
 		B80F45BC25411271004F8A22 /* TrendingListSectionViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B80F45BB25411271004F8A22 /* TrendingListSectionViewModel.swift */; };
 		B81C86FD250A1370000B9E5F /* LibraryViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B81C86FC250A1370000B9E5F /* LibraryViewModel.swift */; };
 		B81C86FF250A2207000B9E5F /* LibraryEntryViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B81C86FE250A2207000B9E5F /* LibraryEntryViewModel.swift */; };
@@ -25,7 +26,6 @@
 		B8462309250AF5A3002358A0 /* DictionaryParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8462308250AF5A3002358A0 /* DictionaryParser.swift */; };
 		B846482F2526CB5000D5A76D /* DictionaryFetcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B846482E2526CB5000D5A76D /* DictionaryFetcherTests.swift */; };
 		B8539EE52519755A000FF025 /* DictionaryStorageManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8539EE42519755A000FF025 /* DictionaryStorageManagerTests.swift */; };
-		B85950FC254954D70057BAB0 /* SearchResults.swift in Sources */ = {isa = PBXBuildFile; fileRef = B85950FB254954D70057BAB0 /* SearchResults.swift */; };
 		B860B7122518207900F48FBE /* JMdict_e.json.gz in Resources */ = {isa = PBXBuildFile; fileRef = B860B7112518207800F48FBE /* JMdict_e.json.gz */; };
 		B8667F102509C745001EABD4 /* AppView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8667F0F2509C745001EABD4 /* AppView.swift */; };
 		B8667F132509CA68001EABD4 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8667F122509CA68001EABD4 /* SettingsView.swift */; };
@@ -50,7 +50,7 @@
 		B8A78EE32542EBD000577974 /* TrendingListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8A78EE22542EBD000577974 /* TrendingListViewModel.swift */; };
 		B8A78EE82542EC3B00577974 /* TrendingList.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8A78EE72542EC3B00577974 /* TrendingList.swift */; };
 		B8A78F072542F26700577974 /* TrendingListSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8A78F062542F26700577974 /* TrendingListSection.swift */; };
-		B8A78F0C2542F27200577974 /* TrendingListItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8A78F0B2542F27200577974 /* TrendingListItem.swift */; };
+		B8A78F0C2542F27200577974 /* DiscoverListItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8A78F0B2542F27200577974 /* DiscoverListItem.swift */; };
 		B8B8F9912526C10400D6DF8B /* DictionaryFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8B8F9902526C10400D6DF8B /* DictionaryFetcher.swift */; };
 		B8D4569A2508D1A2000F9E5F /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8D456992508D1A2000F9E5F /* AppDelegate.swift */; };
 		B8D4569C2508D1A2000F9E5F /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8D4569B2508D1A2000F9E5F /* SceneDelegate.swift */; };
@@ -95,7 +95,8 @@
 		4C9134A1E97C7A555EA7B8DB /* Pods-ReedTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ReedTests.release.xcconfig"; path = "Target Support Files/Pods-ReedTests/Pods-ReedTests.release.xcconfig"; sourceTree = "<group>"; };
 		6DCF77DA252DB19B00CB3C5D /* ReaderViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderViewModel.swift; sourceTree = "<group>"; };
 		B8093DD5251A988200D95DCF /* NotificationName+DictionaryParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NotificationName+DictionaryParser.swift"; sourceTree = "<group>"; };
-		B80CBD262542887700C807CD /* TrendingListItemViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrendingListItemViewModel.swift; sourceTree = "<group>"; };
+		B80CBD262542887700C807CD /* DiscoverListItemViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscoverListItemViewModel.swift; sourceTree = "<group>"; };
+		B80E0E6A25497E13009B0EE8 /* SearchResults.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SearchResults.swift; sourceTree = "<group>"; };
 		B80F45BB25411271004F8A22 /* TrendingListSectionViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrendingListSectionViewModel.swift; sourceTree = "<group>"; };
 		B81C86FC250A1370000B9E5F /* LibraryViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryViewModel.swift; sourceTree = "<group>"; };
 		B81C86FE250A2207000B9E5F /* LibraryEntryViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryEntryViewModel.swift; sourceTree = "<group>"; };
@@ -108,7 +109,6 @@
 		B8462308250AF5A3002358A0 /* DictionaryParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictionaryParser.swift; sourceTree = "<group>"; };
 		B846482E2526CB5000D5A76D /* DictionaryFetcherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictionaryFetcherTests.swift; sourceTree = "<group>"; };
 		B8539EE42519755A000FF025 /* DictionaryStorageManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictionaryStorageManagerTests.swift; sourceTree = "<group>"; };
-		B85950FB254954D70057BAB0 /* SearchResults.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchResults.swift; sourceTree = "<group>"; };
 		B860B7112518207800F48FBE /* JMdict_e.json.gz */ = {isa = PBXFileReference; lastKnownFileType = archive.gzip; path = JMdict_e.json.gz; sourceTree = "<group>"; };
 		B8667F0F2509C745001EABD4 /* AppView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppView.swift; sourceTree = "<group>"; };
 		B8667F122509CA68001EABD4 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
@@ -132,7 +132,7 @@
 		B8A78EE22542EBD000577974 /* TrendingListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrendingListViewModel.swift; sourceTree = "<group>"; };
 		B8A78EE72542EC3B00577974 /* TrendingList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrendingList.swift; sourceTree = "<group>"; };
 		B8A78F062542F26700577974 /* TrendingListSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrendingListSection.swift; sourceTree = "<group>"; };
-		B8A78F0B2542F27200577974 /* TrendingListItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrendingListItem.swift; sourceTree = "<group>"; };
+		B8A78F0B2542F27200577974 /* DiscoverListItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscoverListItem.swift; sourceTree = "<group>"; };
 		B8B8F9902526C10400D6DF8B /* DictionaryFetcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictionaryFetcher.swift; sourceTree = "<group>"; };
 		B8D456962508D1A2000F9E5F /* Reed.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Reed.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		B8D456992508D1A2000F9E5F /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -222,7 +222,6 @@
 			isa = PBXGroup;
 			children = (
 				B80F45BB25411271004F8A22 /* TrendingListSectionViewModel.swift */,
-				B80CBD262542887700C807CD /* TrendingListItemViewModel.swift */,
 				B8A78EE22542EBD000577974 /* TrendingListViewModel.swift */,
 			);
 			path = viewmodels;
@@ -267,8 +266,8 @@
 		B82AF6422548148100FAB2A8 /* views */ = {
 			isa = PBXGroup;
 			children = (
+				B80E0E6A25497E13009B0EE8 /* SearchResults.swift */,
 				B82AF6442548148100FAB2A8 /* SearchHistory.swift */,
-				B85950FB254954D70057BAB0 /* SearchResults.swift */,
 			);
 			path = views;
 			sourceTree = "<group>";
@@ -334,7 +333,6 @@
 			children = (
 				B8A78EE72542EC3B00577974 /* TrendingList.swift */,
 				B8A78F062542F26700577974 /* TrendingListSection.swift */,
-				B8A78F0B2542F27200577974 /* TrendingListItem.swift */,
 			);
 			path = views;
 			sourceTree = "<group>";
@@ -503,6 +501,8 @@
 		B8D456D02508D8DD000F9E5F /* DiscoverTab */ = {
 			isa = PBXGroup;
 			children = (
+				B8A78F0B2542F27200577974 /* DiscoverListItem.swift */,
+				B80CBD262542887700C807CD /* DiscoverListItemViewModel.swift */,
 				B89CD68525098C0100D7D8ED /* DiscoverView.swift */,
 				B89AB0DD2544857F001FC480 /* TrendingView */,
 				B82AF63F2548148100FAB2A8 /* SearchView */,
@@ -721,6 +721,7 @@
 			files = (
 				B8F5C20E250EDDB2000810F8 /* DictionaryEntry+CoreDataProperties.swift in Sources */,
 				B8F5C20F250EDDB2000810F8 /* DictionaryReading+CoreDataClass.swift in Sources */,
+				B80E0E6B25497E13009B0EE8 /* SearchResults.swift in Sources */,
 				B8F5C215250EDEEB000810F8 /* DictionaryDefinition+CoreDataClass.swift in Sources */,
 				B89CD6922509930100D7D8ED /* VocabularyListsView.swift in Sources */,
 				B87D30772516C537002E25FF /* DictionaryLanguageSource+CoreDataClass.swift in Sources */,
@@ -734,7 +735,7 @@
 				B80F45BC25411271004F8A22 /* TrendingListSectionViewModel.swift in Sources */,
 				B880D139251810F20097AF8D /* SplashViewModel.swift in Sources */,
 				B8D456D62508DD24000F9E5F /* LibraryEntryView.swift in Sources */,
-				B80CBD272542887700C807CD /* TrendingListItemViewModel.swift in Sources */,
+				B80CBD272542887700C807CD /* DiscoverListItemViewModel.swift in Sources */,
 				B898110B250F81600059F71F /* NSManagedObject+Init.swift in Sources */,
 				B8A78EE32542EBD000577974 /* TrendingListViewModel.swift in Sources */,
 				B8D4569F2508D1A2000F9E5F /* Reed.xcdatamodeld in Sources */,
@@ -755,7 +756,6 @@
 				B89810F8250F17210059F71F /* DictionaryStorageManager.swift in Sources */,
 				6DCF77DB252DB19B00CB3C5D /* ReaderViewModel.swift in Sources */,
 				B8462309250AF5A3002358A0 /* DictionaryParser.swift in Sources */,
-				B85950FC254954D70057BAB0 /* SearchResults.swift in Sources */,
 				B8F04A892517F07500405599 /* SplashView.swift in Sources */,
 				B8F5C216250EDEEB000810F8 /* DictionaryDefinition+CoreDataProperties.swift in Sources */,
 				B89CD698250993F800D7D8ED /* DefinitionModal.swift in Sources */,
@@ -763,7 +763,7 @@
 				B81C86FF250A2207000B9E5F /* LibraryEntryViewModel.swift in Sources */,
 				B89CD69A2509944200D7D8ED /* MockCards.swift in Sources */,
 				B82AF5FD2548031F00FAB2A8 /* SearchBar.swift in Sources */,
-				B8A78F0C2542F27200577974 /* TrendingListItem.swift in Sources */,
+				B8A78F0C2542F27200577974 /* DiscoverListItem.swift in Sources */,
 				B89CD6942509934700D7D8ED /* VocabularyListView.swift in Sources */,
 				B81C8702250A3675000B9E5F /* MockLibraryEntryData.swift in Sources */,
 				B8D4569C2508D1A2000F9E5F /* SceneDelegate.swift in Sources */,

--- a/Reed.xcodeproj/project.pbxproj
+++ b/Reed.xcodeproj/project.pbxproj
@@ -13,6 +13,8 @@
 		B8093DD6251A988200D95DCF /* NotificationName+DictionaryParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8093DD5251A988200D95DCF /* NotificationName+DictionaryParser.swift */; };
 		B80CBD272542887700C807CD /* DiscoverListItemViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B80CBD262542887700C807CD /* DiscoverListItemViewModel.swift */; };
 		B80E0E6B25497E13009B0EE8 /* SearchResults.swift in Sources */ = {isa = PBXBuildFile; fileRef = B80E0E6A25497E13009B0EE8 /* SearchResults.swift */; };
+		B80E0E7025497EBA009B0EE8 /* DiscoverSearchResultsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B80E0E6F25497EBA009B0EE8 /* DiscoverSearchResultsViewModel.swift */; };
+		B80E0E75254A225B009B0EE8 /* UINavigationController+UIGestureRecognizerDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B80E0E74254A225B009B0EE8 /* UINavigationController+UIGestureRecognizerDelegate.swift */; };
 		B80F45BC25411271004F8A22 /* TrendingListSectionViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B80F45BB25411271004F8A22 /* TrendingListSectionViewModel.swift */; };
 		B81C86FD250A1370000B9E5F /* LibraryViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B81C86FC250A1370000B9E5F /* LibraryViewModel.swift */; };
 		B81C86FF250A2207000B9E5F /* LibraryEntryViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B81C86FE250A2207000B9E5F /* LibraryEntryViewModel.swift */; };
@@ -97,6 +99,8 @@
 		B8093DD5251A988200D95DCF /* NotificationName+DictionaryParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NotificationName+DictionaryParser.swift"; sourceTree = "<group>"; };
 		B80CBD262542887700C807CD /* DiscoverListItemViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscoverListItemViewModel.swift; sourceTree = "<group>"; };
 		B80E0E6A25497E13009B0EE8 /* SearchResults.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SearchResults.swift; sourceTree = "<group>"; };
+		B80E0E6F25497EBA009B0EE8 /* DiscoverSearchResultsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscoverSearchResultsViewModel.swift; sourceTree = "<group>"; };
+		B80E0E74254A225B009B0EE8 /* UINavigationController+UIGestureRecognizerDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UINavigationController+UIGestureRecognizerDelegate.swift"; sourceTree = "<group>"; };
 		B80F45BB25411271004F8A22 /* TrendingListSectionViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrendingListSectionViewModel.swift; sourceTree = "<group>"; };
 		B81C86FC250A1370000B9E5F /* LibraryViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryViewModel.swift; sourceTree = "<group>"; };
 		B81C86FE250A2207000B9E5F /* LibraryEntryViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryEntryViewModel.swift; sourceTree = "<group>"; };
@@ -290,6 +294,7 @@
 			isa = PBXGroup;
 			children = (
 				B82AF65D2548187200FAB2A8 /* DiscoverSearchViewModel.swift */,
+				B80E0E6F25497EBA009B0EE8 /* DiscoverSearchResultsViewModel.swift */,
 			);
 			path = viewmodels;
 			sourceTree = "<group>";
@@ -315,6 +320,7 @@
 			isa = PBXGroup;
 			children = (
 				B898110A250F81600059F71F /* NSManagedObject+Init.swift */,
+				B80E0E74254A225B009B0EE8 /* UINavigationController+UIGestureRecognizerDelegate.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -727,6 +733,7 @@
 				B87D30772516C537002E25FF /* DictionaryLanguageSource+CoreDataClass.swift in Sources */,
 				B89CD68B2509900000D7D8ED /* MockReaderData.swift in Sources */,
 				B8F5C217250EDEEB000810F8 /* DictionaryTerm+CoreDataClass.swift in Sources */,
+				B80E0E75254A225B009B0EE8 /* UINavigationController+UIGestureRecognizerDelegate.swift in Sources */,
 				B89CD68E2509928800D7D8ED /* ReaderView.swift in Sources */,
 				B8D4569A2508D1A2000F9E5F /* AppDelegate.swift in Sources */,
 				B82AF5DF2548015B00FAB2A8 /* View+UIKitComponents.swift in Sources */,
@@ -736,6 +743,7 @@
 				B880D139251810F20097AF8D /* SplashViewModel.swift in Sources */,
 				B8D456D62508DD24000F9E5F /* LibraryEntryView.swift in Sources */,
 				B80CBD272542887700C807CD /* DiscoverListItemViewModel.swift in Sources */,
+				B80E0E7025497EBA009B0EE8 /* DiscoverSearchResultsViewModel.swift in Sources */,
 				B898110B250F81600059F71F /* NSManagedObject+Init.swift in Sources */,
 				B8A78EE32542EBD000577974 /* TrendingListViewModel.swift in Sources */,
 				B8D4569F2508D1A2000F9E5F /* Reed.xcdatamodeld in Sources */,

--- a/Reed/DiscoverTab/DiscoverListItem.swift
+++ b/Reed/DiscoverTab/DiscoverListItem.swift
@@ -1,5 +1,5 @@
 //
-//  TrendingListItem.swift
+//  DiscoverListItem.swift
 //  Reed
 //
 //  Created by Roger Luo on 10/23/20.
@@ -9,8 +9,8 @@
 import SwiftUI
 import struct SwiftyNarou.NarouResponse
 
-struct TrendingListItem: View {
-    @ObservedObject var viewModel: TrendingListItemViewModel
+struct DiscoverListItem: View {
+    @ObservedObject var viewModel: DiscoverListItemViewModel
     
     var body: some View {
         VStack(alignment: .leading) {
@@ -27,10 +27,10 @@ struct TrendingListItem: View {
     }
 }
 
-struct TrendingListSectionItem_Previews: PreviewProvider {
+struct DiscoverListItem_Previews: PreviewProvider {
     static var previews: some View {
-        TrendingListItem(
-            viewModel: TrendingListItemViewModel(
+        DiscoverListItem(
+            viewModel: DiscoverListItemViewModel(
                 from: NarouResponse(
                     title: "無職転生　- 異世界行ったら本気だす -",
                     ncode: "n9669bk",

--- a/Reed/DiscoverTab/DiscoverListItemViewModel.swift
+++ b/Reed/DiscoverTab/DiscoverListItemViewModel.swift
@@ -10,7 +10,7 @@ import SwiftUI
 import enum SwiftyNarou.Subgenre
 import struct SwiftyNarou.NarouResponse
 
-class TrendingListItemViewModel: ObservableObject {
+class DiscoverListItemViewModel: ObservableObject {
     let ncode: String
     let title: String
     let author: String
@@ -24,14 +24,14 @@ class TrendingListItemViewModel: ObservableObject {
     }
 }
 
-extension TrendingListItemViewModel: Hashable, Equatable {
+extension DiscoverListItemViewModel: Hashable, Equatable {
     func hash(into hasher: inout Hasher) {
         hasher.combine(ncode)
     }
     
     static func == (
-        lhs: TrendingListItemViewModel,
-        rhs: TrendingListItemViewModel
+        lhs: DiscoverListItemViewModel,
+        rhs: DiscoverListItemViewModel
     ) -> Bool {
         return lhs.ncode == rhs.ncode
     }

--- a/Reed/DiscoverTab/DiscoverView.swift
+++ b/Reed/DiscoverTab/DiscoverView.swift
@@ -9,7 +9,7 @@
 import SwiftUI
 
 struct DiscoverView: View {
-    @ObservedObject var searchViewModel: DiscoverSearchViewModel = DiscoverSearchViewModel()
+    @ObservedObject var searchViewModel = DiscoverSearchViewModel()
     
     var body: some View {
         NavigationView {
@@ -23,9 +23,7 @@ struct DiscoverView: View {
                 }
                 NavigationLink(
                     destination: SearchResults(
-                        viewModel: DiscoverSearchResultsViewModel(
-                            keyword: searchViewModel.searchBar.searchText
-                        )
+                        viewModel: searchViewModel.searchResultsViewModel
                     ),
                     isActive: $searchViewModel.pushSearchResults
                 ) {

--- a/Reed/DiscoverTab/DiscoverView.swift
+++ b/Reed/DiscoverTab/DiscoverView.swift
@@ -22,7 +22,11 @@ struct DiscoverView: View {
                     )
                 }
                 NavigationLink(
-                    destination: SearchResults(),
+                    destination: SearchResults(
+                        viewModel: DiscoverSearchResultsViewModel(
+                            keyword: searchViewModel.searchBar.searchText
+                        )
+                    ),
                     isActive: $searchViewModel.pushSearchResults
                 ) {
                     EmptyView()

--- a/Reed/DiscoverTab/SearchView/viewmodels/DiscoverSearchResultsViewModel.swift
+++ b/Reed/DiscoverTab/SearchView/viewmodels/DiscoverSearchResultsViewModel.swift
@@ -1,0 +1,49 @@
+//
+//  DiscoverSearchResultsViewModel.swift
+//  Reed
+//
+//  Created by Roger Luo on 10/28/20.
+//  Copyright © 2020 Roger Luo. All rights reserved.
+//
+
+import SwiftUI
+import SwiftyNarou
+
+class DiscoverSearchResultsViewModel: ObservableObject {
+    @Published var searchResults: [DiscoverListItemViewModel] = []
+    var request: NarouRequest?
+    let keyword: String
+    var start: Int = 0
+    
+    init(keyword: String) {
+        self.keyword = keyword
+        createRequest(with: keyword)
+        fetchSearchResults(using: request)
+    }
+    
+    func createRequest(with keyword: String) {
+        request = NarouRequest(
+            word: keyword,
+            responseFormat: NarouResponseFormat(
+                gzipCompressionLevel: 5,
+                fileFormat: .JSON,
+                fields: [.ncode, .novelTitle, .author, .subgenre],
+                start: start,
+                order: .mostPopularWeek
+            )
+        )
+    }
+    
+    func fetchSearchResults(using request: NarouRequest?) {
+        guard let request = request else { return }
+        
+        Narou.fetchNarouApi(request: request) { data, error in
+            if error != nil { return }
+            if let data = data {
+                for entry in data {
+                    self.searchResults.append(DiscoverListItemViewModel(from: entry))
+                }
+            }
+        }
+    }
+}

--- a/Reed/DiscoverTab/SearchView/viewmodels/DiscoverSearchViewModel.swift
+++ b/Reed/DiscoverTab/SearchView/viewmodels/DiscoverSearchViewModel.swift
@@ -10,6 +10,8 @@ import SwiftUI
 
 class DiscoverSearchViewModel: ObservableObject {
     let searchBar: SearchBar = SearchBar(shouldObscureBackground: false)
+    var searchResultsViewModel: DiscoverSearchResultsViewModel = DiscoverSearchResultsViewModel(keyword: "")
+    
     @Published var isSearching: Bool = false
     @Published var pushSearchResults = false
     @Published var searchHistory: [String] = [] // TODO: consider making this a queue
@@ -71,6 +73,7 @@ extension DiscoverSearchViewModel {
 /// Methods for the SearchBar
 extension DiscoverSearchViewModel {
     func onClickSearch(keyword: String) {
+        searchResultsViewModel = DiscoverSearchResultsViewModel(keyword: keyword)
         searchBar.searchController.searchBar.text = keyword
         appendToSearchHistory(keyword)
         pushSearchResults = true

--- a/Reed/DiscoverTab/SearchView/views/SearchResults.swift
+++ b/Reed/DiscoverTab/SearchView/views/SearchResults.swift
@@ -7,15 +7,41 @@
 //
 
 import SwiftUI
+import struct SwiftyNarou.NarouRequest
+import struct SwiftyNarou.NarouResponseFormat
 
 struct SearchResults: View {
+    @ObservedObject var viewModel: DiscoverSearchResultsViewModel
+    
+    @Environment(\.presentationMode) var presentationMode: Binding<PresentationMode>
+    var btnBack : some View { Button(action: {
+        self.presentationMode.wrappedValue.dismiss()
+        }) {
+            HStack {
+                Image(systemName: "chevron.backward")
+                    .imageScale(.large)
+                Text("Search")
+                    .font(.callout)
+                    .fontWeight(.regular)
+            }
+        }
+    }
+    
     var body: some View {
-        Text("Results!")
+        List {
+            ForEach(viewModel.searchResults, id: \.self) {
+                DiscoverListItem(viewModel: $0)
+            }
+        }
+        .navigationBarTitle(viewModel.keyword, displayMode: .inline)
+        .navigationBarBackButtonHidden(true)
+        .navigationBarItems(leading: btnBack)
     }
 }
 
 struct SearchResults_Previews: PreviewProvider {
     static var previews: some View {
-        SearchResults()
+        SearchResults(viewModel: DiscoverSearchResultsViewModel(keyword: "無職転生"))
     }
 }
+

--- a/Reed/DiscoverTab/SearchView/views/SearchResults.swift
+++ b/Reed/DiscoverTab/SearchView/views/SearchResults.swift
@@ -32,6 +32,11 @@ struct SearchResults: View {
             ForEach(viewModel.searchResults, id: \.self) {
                 DiscoverListItem(viewModel: $0)
             }
+            Spacer()
+                .onAppear {
+                    let request = self.viewModel.createRequest()
+                    self.viewModel.fetchSearchResults(using: request)
+                }
         }
         .navigationBarTitle(viewModel.keyword, displayMode: .inline)
         .navigationBarBackButtonHidden(true)
@@ -41,7 +46,9 @@ struct SearchResults: View {
 
 struct SearchResults_Previews: PreviewProvider {
     static var previews: some View {
-        SearchResults(viewModel: DiscoverSearchResultsViewModel(keyword: "無職転生"))
+        SearchResults(
+            viewModel: DiscoverSearchResultsViewModel(keyword: "無職転生")
+        )
     }
 }
 

--- a/Reed/DiscoverTab/TrendingView/viewmodels/TrendingListSectionViewModel.swift
+++ b/Reed/DiscoverTab/TrendingView/viewmodels/TrendingListSectionViewModel.swift
@@ -10,7 +10,7 @@ import SwiftUI
 import SwiftyNarou
 
 class TrendingListSectionViewModel: ObservableObject {
-    @Published var items: [TrendingListItemViewModel] = []
+    @Published var items: [DiscoverListItemViewModel] = []
     let header: String
     var request: NarouRequest!
     
@@ -33,7 +33,7 @@ class TrendingListSectionViewModel: ObservableObject {
             }
             if let data = data {
                 for entry in data {
-                    self.items.append(TrendingListItemViewModel(from: entry))
+                    self.items.append(DiscoverListItemViewModel(from: entry))
                 }
             }
         }

--- a/Reed/DiscoverTab/TrendingView/views/TrendingListSection.swift
+++ b/Reed/DiscoverTab/TrendingView/views/TrendingListSection.swift
@@ -14,7 +14,7 @@ struct TrendingListSection: View {
     var body: some View {
         Section(header: Text(viewModel.header)) {
             ForEach(viewModel.items, id: \.self) {
-                TrendingListItem(viewModel: $0)
+                DiscoverListItem(viewModel: $0)
             }
         }
     }

--- a/Reed/Extensions/UINavigationController+UIGestureRecognizerDelegate.swift
+++ b/Reed/Extensions/UINavigationController+UIGestureRecognizerDelegate.swift
@@ -1,0 +1,21 @@
+//
+//  UINavigationController+UIGestureRecognizerDelegate.swift
+//  Reed
+//
+//  Created by Roger Luo on 10/28/20.
+//  Copyright © 2020 Roger Luo. All rights reserved.
+//
+
+import SwiftUI
+
+/// Preserves NavigationView left swipe when hidden.
+extension UINavigationController: UIGestureRecognizerDelegate {
+    override open func viewDidLoad() {
+        super.viewDidLoad()
+        interactivePopGestureRecognizer?.delegate = self
+    }
+
+    public func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
+        return viewControllers.count > 1
+    }
+}


### PR DESCRIPTION
Commit 1: Refactor `TrendingListItem` to `DiscoverListItem`
It turns out that TrendingListItem will be used for rendering lists in multiple discover views, so we refactor it and its view model for reusability.

Commit 2: Implement loading search result data, view popping.
This commit implements the functionality for a `SearchResults` view to load Narou data using the query term. We also change the NavigationView's back button to show "Search" instead of "Discover" because the `SearchResults` view pops back to the `SearchHistory` view.

Commit 3: Infinite scroll
Implements infinite scroll for the `SearchResults` view. SwiftUI has no way of determining when the end of a scroll view has been reached, so we place a dummy Spacer at the end of the `SearchResults` `List` and trigger a load each time it renders.