### PR TITLE
DiscoverTab/SearchView: Fix two infinite scroll bugs.

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -3,7 +3,7 @@ PODS:
   - SwiftSoup (2.3.2)
   - SwiftUIPager (1.12.0)
   - SwiftyJSON (5.0.0)
-  - SwiftyNarou (1.1.7):
+  - SwiftyNarou (1.1.8):
     - GzipSwift
     - SwiftSoup
     - SwiftyJSON
@@ -27,7 +27,7 @@ SPEC CHECKSUMS:
   SwiftSoup: f97bc4e988c7729d6457f9642f974c617a6e2510
   SwiftUIPager: 84ce7c56d42a70a8c1337de14207ab5ff11dc0a9
   SwiftyJSON: 36413e04c44ee145039d332b4f4e2d3e8d6c4db7
-  SwiftyNarou: 06dee2ab885c978a8c7ce63aa71b3c5cbd8eae6a
+  SwiftyNarou: f3be1a52ee6387cd54f9da798a3f72758786644d
 
 PODFILE CHECKSUM: 65a051bb19988195c9d1581d65c7c8a1679e01a5
 

--- a/Reed/DiscoverTab/SearchView/viewmodels/DiscoverSearchResultsViewModel.swift
+++ b/Reed/DiscoverTab/SearchView/viewmodels/DiscoverSearchResultsViewModel.swift
@@ -9,50 +9,60 @@
 import SwiftUI
 import SwiftyNarou
 
-class DiscoverSearchResultsViewModel: ObservableObject {
-    @Published var searchResults: [DiscoverListItemViewModel] = []
-    var request: NarouRequest?
-    var keyword: String
-
+enum SearchResultsConstants: Int {
     /* Must be a number large enough to make the screen scroll,
      or else the pagination will fail because the Spacer
      won't be able to move below new entries to "appear" again. */
-    let LOAD_INCREMENT = 20
+    case LOAD_INCREMENT = 20
+    case MAX_RESULT_INDEX = 2000
+}
+
+class DiscoverSearchResultsViewModel: ObservableObject {
+    @Published var searchResults: [DiscoverListItemViewModel] = []
+    var startIndex: Int = -SearchResultsConstants.LOAD_INCREMENT.rawValue
+    var resultCount: Int = 0
+    let keyword: String
     
     init(keyword: String) {
         self.keyword = keyword
-        request = createRequest()
-        fetchSearchResults(using: request)
+        updateSearchResults()
     }
     
-    func createRequest() -> NarouRequest? {
+    func updateSearchResults() {
+        guard let request = createRequest() else { return }
+        Narou.fetchNarouApi(request: request) { data, error in
+            if error != nil { return }
+            if let data = data {
+                self.resultCount = min(
+                    data.0,
+                    SearchResultsConstants.MAX_RESULT_INDEX.rawValue
+                )
+                for entry in data.1 {
+                    self.searchResults.append(
+                        DiscoverListItemViewModel(from: entry)
+                    )
+                }
+            }
+        }
+    }
+    
+    private func createRequest() -> NarouRequest? {
         if keyword == "" { return nil }
         
-        let startIndex = request?.responseFormat?.startIndex ?? -LOAD_INCREMENT
-        if startIndex + LOAD_INCREMENT >= 2000 { return nil }
+        let increment = SearchResultsConstants.LOAD_INCREMENT.rawValue
+        if startIndex + increment > resultCount { return nil }
         
+        startIndex += increment
         return NarouRequest(
             word: keyword,
             responseFormat: NarouResponseFormat(
                 gzipCompressionLevel: 5,
                 fileFormat: .JSON,
                 fields: [.ncode, .novelTitle, .author, .subgenre],
-                limit: LOAD_INCREMENT,
-                startIndex: startIndex + LOAD_INCREMENT,
+                limit: increment - 1, // offset by one to avoid duplicating last row
+                startIndex: startIndex,
                 order: .mostPopularWeek
             )
         )
-    }
-    
-    func fetchSearchResults(using request: NarouRequest?) {
-        guard let request = request else { return }
-        Narou.fetchNarouApi(request: request) { data, error in
-            if error != nil { return }
-            if let data = data {
-                for entry in data {
-                    self.searchResults.append(DiscoverListItemViewModel(from: entry))
-                }
-            }
-        }
     }
 }

--- a/Reed/DiscoverTab/SearchView/views/SearchResults.swift
+++ b/Reed/DiscoverTab/SearchView/views/SearchResults.swift
@@ -29,14 +29,13 @@ struct SearchResults: View {
     
     var body: some View {
         List {
-            ForEach(viewModel.searchResults, id: \.self) {
-                DiscoverListItem(viewModel: $0)
-            }
-            Spacer()
-                .onAppear {
-                    let request = self.viewModel.createRequest()
-                    self.viewModel.fetchSearchResults(using: request)
+            ForEach(viewModel.searchResults, id: \.self) { result in
+                DiscoverListItem(viewModel: result).onAppear {
+                    if self.viewModel.searchResults.last == result {
+                        self.viewModel.updateSearchResults()
+                    }
                 }
+            }
         }
         .navigationBarTitle(viewModel.keyword, displayMode: .inline)
         .navigationBarBackButtonHidden(true)

--- a/Reed/DiscoverTab/TrendingView/viewmodels/TrendingListSectionViewModel.swift
+++ b/Reed/DiscoverTab/TrendingView/viewmodels/TrendingListSectionViewModel.swift
@@ -32,7 +32,7 @@ class TrendingListSectionViewModel: ObservableObject {
                 return
             }
             if let data = data {
-                for entry in data {
+                for entry in data.1 {
                     self.items.append(DiscoverListItemViewModel(from: entry))
                 }
             }


### PR DESCRIPTION
Bug 1: Infinite scroll would continue to load and append contents even when all query rows have been exhausted. 
Updated SwiftyNarou to provide `allcount` information, which is the total number of rows a query can return. We compare the next query index (`startIndex + LOAD_INCREMENT`) to `allcount` to decide whether we want to fetch new rows.

Bug 2: The last row of the current list and the first row of the incoming list are the same.
Fixed by setting limit to one less than the increment.