### PR TITLE
DiscoverTab: Fix DiscoverView loading issue.

### DIFF
--- a/Reed/DiscoverTab/DiscoverView.swift
+++ b/Reed/DiscoverTab/DiscoverView.swift
@@ -10,16 +10,20 @@ import SwiftUI
 
 struct DiscoverView: View {
     @ObservedObject var searchViewModel = DiscoverSearchViewModel()
-    @State private var activeCategory: DiscoverListCategory = .recent
+    @ObservedObject var viewModel = DiscoverViewModel()
     
     var body: some View {
         NavigationView {
             ScrollView {
                 ZStack {
                     VStack {
-                        CategoryButtons(activeCategory: $activeCategory)
+                        CategoryButtons(
+                            activeCategory: $viewModel.category,
+                            updateCategory: viewModel.updateCategory
+                        )
                         DiscoverList(
-                            category: $activeCategory
+                            rows: $viewModel.rows,
+                            updateRows: viewModel.updateRows
                         )
                     }
                     

--- a/Reed/DiscoverTab/DiscoverView/viewmodels/DiscoverListViewModel.swift
+++ b/Reed/DiscoverTab/DiscoverView/viewmodels/DiscoverListViewModel.swift
@@ -29,18 +29,18 @@ enum DiscoverListCategory: Equatable {
     }
 }
 
-class DiscoverListViewModel: ObservableObject {
+class DiscoverViewModel: ObservableObject {
     @Published var rows: [DiscoverListItemViewModel] = []
-    let category: DiscoverListCategory
+    @Published var category: DiscoverListCategory = .recent
     var startIndex: Int = -FetchNarouConstants.LOAD_INCREMENT.rawValue
     var resultCount: Int = 0
     
-    init(category: DiscoverListCategory) {
-        self.category = category
+    init() {
         updateRows()
     }
     
     func updateRows() {
+        print(startIndex)
         guard let request = createRequest(for: category) else { return }
         Narou.fetchNarouApi(request: request) { data, error in
             if error != nil { return }
@@ -81,5 +81,17 @@ class DiscoverListViewModel: ObservableObject {
                 order: .mostPopularWeek
             )
         )
+    }
+    
+    func updateCategory(newCategory: DiscoverListCategory) {
+        category = newCategory
+        resetData()
+    }
+    
+    private func resetData() {
+        rows = []
+        startIndex = -FetchNarouConstants.LOAD_INCREMENT.rawValue
+        resultCount = 0
+        updateRows()
     }
 }

--- a/Reed/DiscoverTab/DiscoverView/views/CategoryButtons.swift
+++ b/Reed/DiscoverTab/DiscoverView/views/CategoryButtons.swift
@@ -9,13 +9,14 @@
 import SwiftUI
 
 struct CategoryButtons: View {
-    @Binding var activeCategory: DiscoverListCategory
     @ObservedObject var viewModel = CategoryButtonsViewModel()
+    @Binding var activeCategory: DiscoverListCategory
+    let updateCategory: (DiscoverListCategory) -> Void
     
     var body: some View {
         HStack {
             ForEach(viewModel.buttonCategories, id: \.self.id) { category in
-                Button(category.id) { activeCategory = category }
+                Button(category.id) { updateCategory(category) }
                 .padding(.horizontal, 4)
                 .padding(4)
                 .background(
@@ -33,6 +34,9 @@ struct CategoryButtons: View {
 
 struct CategoryButtons_Previews: PreviewProvider {
     static var previews: some View {
-        CategoryButtons(activeCategory: .constant(.recent))
+        CategoryButtons(
+            activeCategory: .constant(.recent),
+            updateCategory: { _ in }
+        )
     }
 }

--- a/Reed/DiscoverTab/DiscoverView/views/DiscoverList.swift
+++ b/Reed/DiscoverTab/DiscoverView/views/DiscoverList.swift
@@ -9,23 +9,16 @@
 import SwiftUI
 
 struct DiscoverList: View {
-    @Binding var category: DiscoverListCategory
-    @ObservedObject var viewModel: DiscoverListViewModel
-    
-    init(
-        category: Binding<DiscoverListCategory>
-    ) {
-        self._category = category
-        viewModel = DiscoverListViewModel(category: category.wrappedValue)
-    }
+    @Binding var rows: [DiscoverListItemViewModel]
+    let updateRows: () -> Void
     
     var body: some View {
         LazyVStack(alignment: .leading) {
             Divider()
-            ForEach(viewModel.rows, id: \.self) { row in
+            ForEach(rows, id: \.self) { row in
                 DiscoverListItem(viewModel: row).onAppear {
-                    if row == self.viewModel.rows.last {
-                        self.viewModel.updateRows()
+                    if row == self.rows.last {
+                        self.updateRows()
                     }
                 }
             }
@@ -36,9 +29,6 @@ struct DiscoverList: View {
 
 struct DiscoverList_Previews: PreviewProvider {
     static var previews: some View {
-        DiscoverList(
-            category: .constant(.recent)
-//            isSearching: .constant(false)
-        )
+        DiscoverList(rows: .constant([]), updateRows: {} )
     }
 }


### PR DESCRIPTION
This commit improves the performance of the DiscoverView by fixing an issue where the DiscoverView re-renders each time the SearchBar is dismissed.

Instead of passing a view model to the `DiscoverList` each time `DiscoverView` is recreated, we create a `DiscoverViewModel` that Publishes both the currently active category and its corresponding rows.