### PR TITLE
Reader: Fix alignment issue

### DIFF
--- a/Reed/Components/TextView.swift
+++ b/Reed/Components/TextView.swift
@@ -16,6 +16,7 @@ struct TextView: UIViewRepresentable {
         let textView = UITextView()
         textView.text = text
         textView.font = .systemFont(ofSize: 18)
+        textView.textAlignment = .justified
         textView.addGestureRecognizer(UITapGestureRecognizer(target: context.coordinator, action: #selector(Coordinator.wordTapped(gesture:))))
         return textView
     }


### PR DESCRIPTION
Fixes the issue of line breaking too early by character by changing the alignment for the UITextView to justified.
before:
<img width="50%" alt="Screen Shot 2020-11-05 at 1 18 54 AM" src="https://user-images.githubusercontent.com/42554019/98222015-2cb09680-1f05-11eb-9221-0f8c5798699c.png">
after:
<img width="50%" alt="Screen Shot 2020-11-05 at 1 19 27 AM" src="https://user-images.githubusercontent.com/42554019/98222042-32a67780-1f05-11eb-9d21-8acf3775e768.png">

