### PR TITLE
Shiori/tokenizer

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -5,6 +5,8 @@ target 'Reed' do
   pod 'SwiftyJSON'
   pod 'SwiftUIPager'
   pod 'SwiftyNarou'
+  pod 'mecab-ko'
+  pod 'mecab-naist-jdic-utf-8'
 
   target 'ReedTests' do
     inherit! :search_paths

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,15 +1,19 @@
 PODS:
   - GzipSwift (5.1.1)
+  - mecab-ko (0.4.0)
+  - mecab-naist-jdic-utf-8 (0.1.3)
   - SwiftSoup (2.3.2)
   - SwiftUIPager (1.13.0)
   - SwiftyJSON (5.0.0)
-  - SwiftyNarou (1.1.8):
+  - SwiftyNarou (1.1.9):
     - GzipSwift
     - SwiftSoup
     - SwiftyJSON
 
 DEPENDENCIES:
   - GzipSwift
+  - mecab-ko
+  - mecab-naist-jdic-utf-8
   - SwiftUIPager
   - SwiftyJSON
   - SwiftyNarou
@@ -17,6 +21,8 @@ DEPENDENCIES:
 SPEC REPOS:
   trunk:
     - GzipSwift
+    - mecab-ko
+    - mecab-naist-jdic-utf-8
     - SwiftSoup
     - SwiftUIPager
     - SwiftyJSON
@@ -24,11 +30,13 @@ SPEC REPOS:
 
 SPEC CHECKSUMS:
   GzipSwift: 893f3e48e597a1a4f62fafcb6514220fcf8287fa
+  mecab-ko: 45633c9b839e8e1f025cd1895ca943de5b3e0efa
+  mecab-naist-jdic-utf-8: 0df05453d30e5774bf28f019eb45507fc8a4f740
   SwiftSoup: f97bc4e988c7729d6457f9642f974c617a6e2510
   SwiftUIPager: 022f9043921d75053c4a8f3eea0b298b6846ee3e
   SwiftyJSON: 36413e04c44ee145039d332b4f4e2d3e8d6c4db7
-  SwiftyNarou: f3be1a52ee6387cd54f9da798a3f72758786644d
+  SwiftyNarou: 106498d81397850e6f1c30b8d7b587d1975e6158
 
-PODFILE CHECKSUM: 65a051bb19988195c9d1581d65c7c8a1679e01a5
+PODFILE CHECKSUM: 3a38352df33c432bff9ce11757de40b500228a58
 
 COCOAPODS: 1.10.0

--- a/Reed.xcodeproj/project.pbxproj
+++ b/Reed.xcodeproj/project.pbxproj
@@ -30,6 +30,7 @@
 		B82D3D95254D2DA200F06836 /* CategoryButtons.swift in Sources */ = {isa = PBXBuildFile; fileRef = B82D3D94254D2DA200F06836 /* CategoryButtons.swift */; };
 		B82D3D9A254D2E7700F06836 /* CategoryButtonsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B82D3D99254D2E7700F06836 /* CategoryButtonsViewModel.swift */; };
 		B82E949325662E98004A6F85 /* PartOfSpeech.swift in Sources */ = {isa = PBXBuildFile; fileRef = B82E949225662E98004A6F85 /* PartOfSpeech.swift */; };
+		B82E94A42566332D004A6F85 /* MecabWordNode.swift in Sources */ = {isa = PBXBuildFile; fileRef = B82E94A32566332D004A6F85 /* MecabWordNode.swift */; };
 		B8462309250AF5A3002358A0 /* DictionaryParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8462308250AF5A3002358A0 /* DictionaryParser.swift */; };
 		B846482F2526CB5000D5A76D /* DictionaryFetcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B846482E2526CB5000D5A76D /* DictionaryFetcherTests.swift */; };
 		B8539EE52519755A000FF025 /* DictionaryStorageManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8539EE42519755A000FF025 /* DictionaryStorageManagerTests.swift */; };
@@ -126,6 +127,7 @@
 		B82D3D94254D2DA200F06836 /* CategoryButtons.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryButtons.swift; sourceTree = "<group>"; };
 		B82D3D99254D2E7700F06836 /* CategoryButtonsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryButtonsViewModel.swift; sourceTree = "<group>"; };
 		B82E949225662E98004A6F85 /* PartOfSpeech.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PartOfSpeech.swift; sourceTree = "<group>"; };
+		B82E94A32566332D004A6F85 /* MecabWordNode.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MecabWordNode.swift; sourceTree = "<group>"; };
 		B8462308250AF5A3002358A0 /* DictionaryParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictionaryParser.swift; sourceTree = "<group>"; };
 		B846482E2526CB5000D5A76D /* DictionaryFetcherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictionaryFetcherTests.swift; sourceTree = "<group>"; };
 		B8539EE42519755A000FF025 /* DictionaryStorageManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictionaryStorageManagerTests.swift; sourceTree = "<group>"; };
@@ -343,6 +345,7 @@
 			children = (
 				B8977923256626D400DF1B79 /* MecabWrapper.swift */,
 				B82E949225662E98004A6F85 /* PartOfSpeech.swift */,
+				B82E94A32566332D004A6F85 /* MecabWordNode.swift */,
 			);
 			path = Tokenizer;
 			sourceTree = "<group>";
@@ -832,6 +835,7 @@
 				B8B8F9912526C10400D6DF8B /* DictionaryFetcher.swift in Sources */,
 				B89CD68625098C0100D7D8ED /* DiscoverView.swift in Sources */,
 				B8667F102509C745001EABD4 /* AppView.swift in Sources */,
+				B82E94A42566332D004A6F85 /* MecabWordNode.swift in Sources */,
 				B8F5C218250EDEEB000810F8 /* DictionaryTerm+CoreDataProperties.swift in Sources */,
 				B8667F132509CA68001EABD4 /* SettingsView.swift in Sources */,
 				B82D3D9A254D2E7700F06836 /* CategoryButtonsViewModel.swift in Sources */,

--- a/Reed.xcodeproj/project.pbxproj
+++ b/Reed.xcodeproj/project.pbxproj
@@ -35,6 +35,7 @@
 		B82E94AE25663890004A6F85 /* DeinflectionRules.swift in Sources */ = {isa = PBXBuildFile; fileRef = B82E94AC25663890004A6F85 /* DeinflectionRules.swift */; };
 		B82E950E256673D5004A6F85 /* DeinflectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B82E950D256673D5004A6F85 /* DeinflectorTests.swift */; };
 		B82E94B3256643C2004A6F85 /* Tokenizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B82E94B2256643C2004A6F85 /* Tokenizer.swift */; };
+		B82E94B825664EA0004A6F85 /* FuriganaMaker.swift in Sources */ = {isa = PBXBuildFile; fileRef = B82E94B725664EA0004A6F85 /* FuriganaMaker.swift */; };
 		B8462309250AF5A3002358A0 /* DictionaryParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8462308250AF5A3002358A0 /* DictionaryParser.swift */; };
 		B846482F2526CB5000D5A76D /* DictionaryFetcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B846482E2526CB5000D5A76D /* DictionaryFetcherTests.swift */; };
 		B8465D3E2566FD0C00967841 /* DefinitionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8465D3D2566FD0C00967841 /* DefinitionView.swift */; };
@@ -136,6 +137,7 @@
 		B82E94AC25663890004A6F85 /* DeinflectionRules.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DeinflectionRules.swift; sourceTree = "<group>"; };
 		B82E950D256673D5004A6F85 /* DeinflectorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DeinflectorTests.swift; sourceTree = "<group>"; };
 		B82E94B2256643C2004A6F85 /* Tokenizer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Tokenizer.swift; sourceTree = "<group>"; };
+		B82E94B725664EA0004A6F85 /* FuriganaMaker.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FuriganaMaker.swift; sourceTree = "<group>"; };
 		B8462308250AF5A3002358A0 /* DictionaryParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictionaryParser.swift; sourceTree = "<group>"; };
 		B846482E2526CB5000D5A76D /* DictionaryFetcherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictionaryFetcherTests.swift; sourceTree = "<group>"; };
 		B8465D3D2566FD0C00967841 /* DefinitionView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DefinitionView.swift; sourceTree = "<group>"; };
@@ -359,6 +361,7 @@
 		B8977921256626D400DF1B79 /* Tokenizer */ = {
 			isa = PBXGroup;
 			children = (
+				B82E94B725664EA0004A6F85 /* FuriganaMaker.swift */,
 				B82E94B2256643C2004A6F85 /* Tokenizer.swift */,
 				B82E94AC25663890004A6F85 /* DeinflectionRules.swift */,
 				B82E94AB25663890004A6F85 /* Deinflector.swift */,
@@ -888,6 +891,7 @@
 				B89CD6942509934700D7D8ED /* VocabularyListView.swift in Sources */,
 				B81C8702250A3675000B9E5F /* MockLibraryEntryData.swift in Sources */,
 				B8D4569C2508D1A2000F9E5F /* SceneDelegate.swift in Sources */,
+				B82E94B825664EA0004A6F85 /* FuriganaMaker.swift in Sources */,
 				B81C86FD250A1370000B9E5F /* LibraryViewModel.swift in Sources */,
 				B8977925256626D400DF1B79 /* MecabWrapper.swift in Sources */,
 				B8F5C20D250EDDB2000810F8 /* DictionaryEntry+CoreDataClass.swift in Sources */,

--- a/Reed.xcodeproj/project.pbxproj
+++ b/Reed.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		6D4F99992551620200CC0DF6 /* DefinitionViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D4F99982551620200CC0DF6 /* DefinitionViewModel.swift */; };
 		6D4F99B82556A0C900CC0DF6 /* BottomSheetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D4F99B72556A0C900CC0DF6 /* BottomSheetView.swift */; };
 		6DCF77DB252DB19B00CB3C5D /* ReaderViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DCF77DA252DB19B00CB3C5D /* ReaderViewModel.swift */; };
+		AB7A1C88AECCC47C55B834C9 /* libPods-Reed.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 94F3E3D17D6E8ABD1BBAC599 /* libPods-Reed.a */; };
 		B2C716B87034AEAD96CF6D9F /* libPods-ReedTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = C6A22C103DD56D3BAC26C4B4 /* libPods-ReedTests.a */; };
 		B8093DD6251A988200D95DCF /* NotificationName+DictionaryParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8093DD5251A988200D95DCF /* NotificationName+DictionaryParser.swift */; };
 		B80CBD272542887700C807CD /* DiscoverListItemViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B80CBD262542887700C807CD /* DiscoverListItemViewModel.swift */; };
@@ -38,6 +39,7 @@
 		B87D30782516C537002E25FF /* DictionaryLanguageSource+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = B87D30762516C537002E25FF /* DictionaryLanguageSource+CoreDataProperties.swift */; };
 		B880D139251810F20097AF8D /* SplashViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B880D138251810F20097AF8D /* SplashViewModel.swift */; };
 		B8939B8425152ED0000399E0 /* DictionaryParserTestUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8939B8325152ED0000399E0 /* DictionaryParserTestUtils.swift */; };
+		B89778D12566233600DF1B79 /* MecabWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = B89778D02566233600DF1B79 /* MecabWrapper.swift */; };
 		B89810F8250F17210059F71F /* DictionaryStorageManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B89810F7250F17210059F71F /* DictionaryStorageManager.swift */; };
 		B89810FA250F504E0059F71F /* TestUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = B89810F9250F504E0059F71F /* TestUtils.swift */; };
 		B8981108250F6D140059F71F /* Reed.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = B8D4569D2508D1A2000F9E5F /* Reed.xcdatamodeld */; };
@@ -65,6 +67,7 @@
 		B8D456BF2508D1A3000F9E5F /* ReedUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8D456BE2508D1A3000F9E5F /* ReedUITests.swift */; };
 		B8D456D62508DD24000F9E5F /* LibraryEntryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8D456D52508DD24000F9E5F /* LibraryEntryView.swift */; };
 		B8E25B8825661B7A007B492E /* MecabWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8E25B8725661B7A007B492E /* MecabWrapper.swift */; };
+		B8D456D82508DD46000F9E5F /* MockBooks.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8D456D72508DD46000F9E5F /* MockBooks.swift */; };
 		B8F04A892517F07500405599 /* SplashView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8F04A882517F07500405599 /* SplashView.swift */; };
 		B8F5C20D250EDDB2000810F8 /* DictionaryEntry+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8F5C209250EDDB2000810F8 /* DictionaryEntry+CoreDataClass.swift */; };
 		B8F5C20E250EDDB2000810F8 /* DictionaryEntry+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8F5C20A250EDDB2000810F8 /* DictionaryEntry+CoreDataProperties.swift */; };
@@ -133,6 +136,7 @@
 		B87D30762516C537002E25FF /* DictionaryLanguageSource+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DictionaryLanguageSource+CoreDataProperties.swift"; sourceTree = "<group>"; };
 		B880D138251810F20097AF8D /* SplashViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplashViewModel.swift; sourceTree = "<group>"; };
 		B8939B8325152ED0000399E0 /* DictionaryParserTestUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictionaryParserTestUtils.swift; sourceTree = "<group>"; };
+		B89778D02566233600DF1B79 /* MecabWrapper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MecabWrapper.swift; sourceTree = "<group>"; };
 		B89810F7250F17210059F71F /* DictionaryStorageManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictionaryStorageManager.swift; sourceTree = "<group>"; };
 		B89810F9250F504E0059F71F /* TestUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestUtils.swift; sourceTree = "<group>"; };
 		B898110A250F81600059F71F /* NSManagedObject+Init.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSManagedObject+Init.swift"; sourceTree = "<group>"; };
@@ -165,7 +169,6 @@
 		B8D456C02508D1A3000F9E5F /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		B8D456D52508DD24000F9E5F /* LibraryEntryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryEntryView.swift; sourceTree = "<group>"; };
 		B8D91017B089018BE0AEBA19 /* Pods-Reed.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Reed.debug.xcconfig"; path = "Target Support Files/Pods-Reed/Pods-Reed.debug.xcconfig"; sourceTree = "<group>"; };
-		B8E25B8725661B7A007B492E /* MecabWrapper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MecabWrapper.swift; sourceTree = "<group>"; };
 		B8E25B8C25661B97007B492E /* Reed-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Reed-Bridging-Header.h"; sourceTree = "<group>"; };
 		B8F04A882517F07500405599 /* SplashView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplashView.swift; sourceTree = "<group>"; };
 		B8F5C209250EDDB2000810F8 /* DictionaryEntry+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DictionaryEntry+CoreDataClass.swift"; sourceTree = "<group>"; };
@@ -188,7 +191,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				F5417F397D38CDF2ADA7D622 /* libPods-Reed.a in Frameworks */,
+				AB7A1C88AECCC47C55B834C9 /* libPods-Reed.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -336,6 +339,14 @@
 			path = SplashScreen;
 			sourceTree = "<group>";
 		};
+		B89778CF2566233600DF1B79 /* Tokenizer */ = {
+			isa = PBXGroup;
+			children = (
+				B89778D02566233600DF1B79 /* MecabWrapper.swift */,
+			);
+			path = Tokenizer;
+			sourceTree = "<group>";
+		};
 		B8981109250F803F0059F71F /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
@@ -443,7 +454,8 @@
 				B8D456AA2508D1A2000F9E5F /* Info.plist */,
 				B8D456CC2508D2E3000F9E5F /* Main */,
 				B82AF5D92548015B00FAB2A8 /* Components */,
-				B8E25B8625661B7A007B492E /* Tokenizer */,
+				B89778CF2566233600DF1B79 /* Tokenizer */,
+				B880D135251810C90097AF8D /* SplashScreen */,
 				B8981109250F803F0059F71F /* Extensions */,
 				B8462307250AF4E4002358A0 /* Dictionary */,
 				B880D135251810C90097AF8D /* SplashScreen */,
@@ -557,12 +569,12 @@
 			path = views;
 			sourceTree = "<group>";
 		};
-		B8E25B8625661B7A007B492E /* Tokenizer */ = {
+		B8D456D42508DCC7000F9E5F /* models */ = {
 			isa = PBXGroup;
 			children = (
-				B8E25B8725661B7A007B492E /* MecabWrapper.swift */,
+				B8D456D72508DD46000F9E5F /* MockBooks.swift */,
 			);
-			path = Tokenizer;
+			path = models;
 			sourceTree = "<group>";
 		};
 		B8F5C219250EF78E000810F8 /* Dictionary */ = {
@@ -801,7 +813,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				B8E25B8825661B7A007B492E /* MecabWrapper.swift in Sources */,
+				B89778D12566233600DF1B79 /* MecabWrapper.swift in Sources */,
 				B8F5C20E250EDDB2000810F8 /* DictionaryEntry+CoreDataProperties.swift in Sources */,
 				B8F5C20F250EDDB2000810F8 /* DictionaryReading+CoreDataClass.swift in Sources */,
 				B80E0E6B25497E13009B0EE8 /* SearchResults.swift in Sources */,

--- a/Reed.xcodeproj/project.pbxproj
+++ b/Reed.xcodeproj/project.pbxproj
@@ -34,6 +34,7 @@
 		B82E94AD25663890004A6F85 /* Deinflector.swift in Sources */ = {isa = PBXBuildFile; fileRef = B82E94AB25663890004A6F85 /* Deinflector.swift */; };
 		B82E94AE25663890004A6F85 /* DeinflectionRules.swift in Sources */ = {isa = PBXBuildFile; fileRef = B82E94AC25663890004A6F85 /* DeinflectionRules.swift */; };
 		B82E950E256673D5004A6F85 /* DeinflectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B82E950D256673D5004A6F85 /* DeinflectorTests.swift */; };
+		B82E94B3256643C2004A6F85 /* Tokenizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B82E94B2256643C2004A6F85 /* Tokenizer.swift */; };
 		B8462309250AF5A3002358A0 /* DictionaryParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8462308250AF5A3002358A0 /* DictionaryParser.swift */; };
 		B846482F2526CB5000D5A76D /* DictionaryFetcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B846482E2526CB5000D5A76D /* DictionaryFetcherTests.swift */; };
 		B8465D3E2566FD0C00967841 /* DefinitionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8465D3D2566FD0C00967841 /* DefinitionView.swift */; };
@@ -134,6 +135,7 @@
 		B82E94AB25663890004A6F85 /* Deinflector.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Deinflector.swift; sourceTree = "<group>"; };
 		B82E94AC25663890004A6F85 /* DeinflectionRules.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DeinflectionRules.swift; sourceTree = "<group>"; };
 		B82E950D256673D5004A6F85 /* DeinflectorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DeinflectorTests.swift; sourceTree = "<group>"; };
+		B82E94B2256643C2004A6F85 /* Tokenizer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Tokenizer.swift; sourceTree = "<group>"; };
 		B8462308250AF5A3002358A0 /* DictionaryParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictionaryParser.swift; sourceTree = "<group>"; };
 		B846482E2526CB5000D5A76D /* DictionaryFetcherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictionaryFetcherTests.swift; sourceTree = "<group>"; };
 		B8465D3D2566FD0C00967841 /* DefinitionView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DefinitionView.swift; sourceTree = "<group>"; };
@@ -357,6 +359,7 @@
 		B8977921256626D400DF1B79 /* Tokenizer */ = {
 			isa = PBXGroup;
 			children = (
+				B82E94B2256643C2004A6F85 /* Tokenizer.swift */,
 				B82E94AC25663890004A6F85 /* DeinflectionRules.swift */,
 				B82E94AB25663890004A6F85 /* Deinflector.swift */,
 				B8977923256626D400DF1B79 /* MecabWrapper.swift */,
@@ -870,6 +873,7 @@
 				B89CD6962509938C00D7D8ED /* VocabularyCardView.swift in Sources */,
 				B82AF6472548148200FAB2A8 /* SearchHistory.swift in Sources */,
 				B89810F8250F17210059F71F /* DictionaryStorageManager.swift in Sources */,
+				B82E94B3256643C2004A6F85 /* Tokenizer.swift in Sources */,
 				6DCF77DB252DB19B00CB3C5D /* ReaderViewModel.swift in Sources */,
 				B8462309250AF5A3002358A0 /* DictionaryParser.swift in Sources */,
 				B8F04A892517F07500405599 /* SplashView.swift in Sources */,

--- a/Reed.xcodeproj/project.pbxproj
+++ b/Reed.xcodeproj/project.pbxproj
@@ -31,8 +31,12 @@
 		B82D3D9A254D2E7700F06836 /* CategoryButtonsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B82D3D99254D2E7700F06836 /* CategoryButtonsViewModel.swift */; };
 		B82E949325662E98004A6F85 /* PartOfSpeech.swift in Sources */ = {isa = PBXBuildFile; fileRef = B82E949225662E98004A6F85 /* PartOfSpeech.swift */; };
 		B82E94A42566332D004A6F85 /* MecabWordNode.swift in Sources */ = {isa = PBXBuildFile; fileRef = B82E94A32566332D004A6F85 /* MecabWordNode.swift */; };
+		B82E94AD25663890004A6F85 /* Deinflector.swift in Sources */ = {isa = PBXBuildFile; fileRef = B82E94AB25663890004A6F85 /* Deinflector.swift */; };
+		B82E94AE25663890004A6F85 /* DeinflectionRules.swift in Sources */ = {isa = PBXBuildFile; fileRef = B82E94AC25663890004A6F85 /* DeinflectionRules.swift */; };
+		B82E950E256673D5004A6F85 /* DeinflectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B82E950D256673D5004A6F85 /* DeinflectorTests.swift */; };
 		B8462309250AF5A3002358A0 /* DictionaryParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8462308250AF5A3002358A0 /* DictionaryParser.swift */; };
 		B846482F2526CB5000D5A76D /* DictionaryFetcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B846482E2526CB5000D5A76D /* DictionaryFetcherTests.swift */; };
+		B8465D3E2566FD0C00967841 /* DefinitionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8465D3D2566FD0C00967841 /* DefinitionView.swift */; };
 		B8539EE52519755A000FF025 /* DictionaryStorageManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8539EE42519755A000FF025 /* DictionaryStorageManagerTests.swift */; };
 		B860B7122518207900F48FBE /* JMdict_e.json.gz in Resources */ = {isa = PBXBuildFile; fileRef = B860B7112518207800F48FBE /* JMdict_e.json.gz */; };
 		B8667F102509C745001EABD4 /* AppView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8667F0F2509C745001EABD4 /* AppView.swift */; };
@@ -52,7 +56,6 @@
 		B89CD6922509930100D7D8ED /* VocabularyListsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B89CD6912509930100D7D8ED /* VocabularyListsView.swift */; };
 		B89CD6942509934700D7D8ED /* VocabularyListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B89CD6932509934700D7D8ED /* VocabularyListView.swift */; };
 		B89CD6962509938C00D7D8ED /* VocabularyCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B89CD6952509938C00D7D8ED /* VocabularyCardView.swift */; };
-		B89CD698250993F800D7D8ED /* DefinitionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B89CD697250993F800D7D8ED /* DefinitionView.swift */; };
 		B89CD69A2509944200D7D8ED /* MockCards.swift in Sources */ = {isa = PBXBuildFile; fileRef = B89CD6992509944200D7D8ED /* MockCards.swift */; };
 		B8A2617F25268B5C00A2FBFD /* Utils.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8A2617E25268B5C00A2FBFD /* Utils.swift */; };
 		B8A5E50E2527BACE003BCF07 /* UtilsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8A5E50D2527BACE003BCF07 /* UtilsTests.swift */; };
@@ -128,8 +131,12 @@
 		B82D3D99254D2E7700F06836 /* CategoryButtonsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryButtonsViewModel.swift; sourceTree = "<group>"; };
 		B82E949225662E98004A6F85 /* PartOfSpeech.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PartOfSpeech.swift; sourceTree = "<group>"; };
 		B82E94A32566332D004A6F85 /* MecabWordNode.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MecabWordNode.swift; sourceTree = "<group>"; };
+		B82E94AB25663890004A6F85 /* Deinflector.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Deinflector.swift; sourceTree = "<group>"; };
+		B82E94AC25663890004A6F85 /* DeinflectionRules.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DeinflectionRules.swift; sourceTree = "<group>"; };
+		B82E950D256673D5004A6F85 /* DeinflectorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DeinflectorTests.swift; sourceTree = "<group>"; };
 		B8462308250AF5A3002358A0 /* DictionaryParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictionaryParser.swift; sourceTree = "<group>"; };
 		B846482E2526CB5000D5A76D /* DictionaryFetcherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictionaryFetcherTests.swift; sourceTree = "<group>"; };
+		B8465D3D2566FD0C00967841 /* DefinitionView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DefinitionView.swift; sourceTree = "<group>"; };
 		B8539EE42519755A000FF025 /* DictionaryStorageManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictionaryStorageManagerTests.swift; sourceTree = "<group>"; };
 		B860B7112518207800F48FBE /* JMdict_e.json.gz */ = {isa = PBXFileReference; lastKnownFileType = archive.gzip; path = JMdict_e.json.gz; sourceTree = "<group>"; };
 		B8667F0F2509C745001EABD4 /* AppView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppView.swift; sourceTree = "<group>"; };
@@ -148,7 +155,6 @@
 		B89CD6912509930100D7D8ED /* VocabularyListsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VocabularyListsView.swift; sourceTree = "<group>"; };
 		B89CD6932509934700D7D8ED /* VocabularyListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VocabularyListView.swift; sourceTree = "<group>"; };
 		B89CD6952509938C00D7D8ED /* VocabularyCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VocabularyCardView.swift; sourceTree = "<group>"; };
-		B89CD697250993F800D7D8ED /* DefinitionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefinitionView.swift; sourceTree = "<group>"; };
 		B89CD6992509944200D7D8ED /* MockCards.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockCards.swift; sourceTree = "<group>"; };
 		B8A2617E25268B5C00A2FBFD /* Utils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Utils.swift; sourceTree = "<group>"; };
 		B8A5E50D2527BACE003BCF07 /* UtilsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UtilsTests.swift; sourceTree = "<group>"; };
@@ -300,6 +306,14 @@
 			path = views;
 			sourceTree = "<group>";
 		};
+		B82E950C256673D5004A6F85 /* Tokenizer */ = {
+			isa = PBXGroup;
+			children = (
+				B82E950D256673D5004A6F85 /* DeinflectorTests.swift */,
+			);
+			path = Tokenizer;
+			sourceTree = "<group>";
+		};
 		B8462307250AF4E4002358A0 /* Dictionary */ = {
 			isa = PBXGroup;
 			children = (
@@ -343,6 +357,8 @@
 		B8977921256626D400DF1B79 /* Tokenizer */ = {
 			isa = PBXGroup;
 			children = (
+				B82E94AC25663890004A6F85 /* DeinflectionRules.swift */,
+				B82E94AB25663890004A6F85 /* Deinflector.swift */,
 				B8977923256626D400DF1B79 /* MecabWrapper.swift */,
 				B82E949225662E98004A6F85 /* PartOfSpeech.swift */,
 				B82E94A32566332D004A6F85 /* MecabWordNode.swift */,
@@ -389,7 +405,7 @@
 			isa = PBXGroup;
 			children = (
 				B89CD68D2509928800D7D8ED /* ReaderView.swift */,
-				B89CD697250993F800D7D8ED /* DefinitionView.swift */,
+				B8465D3D2566FD0C00967841 /* DefinitionView.swift */,
 			);
 			path = views;
 			sourceTree = "<group>";
@@ -458,7 +474,6 @@
 				B8D456CC2508D2E3000F9E5F /* Main */,
 				B82AF5D92548015B00FAB2A8 /* Components */,
 				B8977921256626D400DF1B79 /* Tokenizer */,
-				B880D135251810C90097AF8D /* SplashScreen */,
 				B8981109250F803F0059F71F /* Extensions */,
 				B8462307250AF4E4002358A0 /* Dictionary */,
 				B880D135251810C90097AF8D /* SplashScreen */,
@@ -484,6 +499,7 @@
 		B8D456B22508D1A2000F9E5F /* ReedTests */ = {
 			isa = PBXGroup;
 			children = (
+				B82E950C256673D5004A6F85 /* Tokenizer */,
 				B8F5C219250EF78E000810F8 /* Dictionary */,
 				B8D456B52508D1A2000F9E5F /* Info.plist */,
 				B89810F9250F504E0059F71F /* TestUtils.swift */,
@@ -811,6 +827,7 @@
 				B8F5C20E250EDDB2000810F8 /* DictionaryEntry+CoreDataProperties.swift in Sources */,
 				B8F5C20F250EDDB2000810F8 /* DictionaryReading+CoreDataClass.swift in Sources */,
 				B80E0E6B25497E13009B0EE8 /* SearchResults.swift in Sources */,
+				B82E94AE25663890004A6F85 /* DeinflectionRules.swift in Sources */,
 				B8F5C215250EDEEB000810F8 /* DictionaryDefinition+CoreDataClass.swift in Sources */,
 				B89CD6922509930100D7D8ED /* VocabularyListsView.swift in Sources */,
 				B87D30772516C537002E25FF /* DictionaryLanguageSource+CoreDataClass.swift in Sources */,
@@ -840,6 +857,7 @@
 				B8667F132509CA68001EABD4 /* SettingsView.swift in Sources */,
 				B82D3D9A254D2E7700F06836 /* CategoryButtonsViewModel.swift in Sources */,
 				B8093DD6251A988200D95DCF /* NotificationName+DictionaryParser.swift in Sources */,
+				B8465D3E2566FD0C00967841 /* DefinitionView.swift in Sources */,
 				B8FA93BE254BBE0D00AE362C /* NavigationLazyView.swift in Sources */,
 				B87D30782516C537002E25FF /* DictionaryLanguageSource+CoreDataProperties.swift in Sources */,
 				B8FA12612550B1E300ABE1D3 /* DiscoverTabConstants.swift in Sources */,
@@ -848,6 +866,7 @@
 				B82AF5FE2548031F00FAB2A8 /* ViewControllerResolver.swift in Sources */,
 				B82AF65E2548187200FAB2A8 /* DiscoverSearchViewModel.swift in Sources */,
 				6D4F99942551619300CC0DF6 /* TextView.swift in Sources */,
+				B82E94AD25663890004A6F85 /* Deinflector.swift in Sources */,
 				B89CD6962509938C00D7D8ED /* VocabularyCardView.swift in Sources */,
 				B82AF6472548148200FAB2A8 /* SearchHistory.swift in Sources */,
 				B89810F8250F17210059F71F /* DictionaryStorageManager.swift in Sources */,
@@ -855,11 +874,9 @@
 				B8462309250AF5A3002358A0 /* DictionaryParser.swift in Sources */,
 				B8F04A892517F07500405599 /* SplashView.swift in Sources */,
 				B8F5C216250EDEEB000810F8 /* DictionaryDefinition+CoreDataProperties.swift in Sources */,
-				B89CD698250993F800D7D8ED /* DefinitionView.swift in Sources */,
 				B82D3D95254D2DA200F06836 /* CategoryButtons.swift in Sources */,
 				B8A78F072542F26700577974 /* DiscoverList.swift in Sources */,
 				B82E949325662E98004A6F85 /* PartOfSpeech.swift in Sources */,
-				B89CD698250993F800D7D8ED /* DefinitionView.swift in Sources */,
 				B81C86FF250A2207000B9E5F /* LibraryEntryViewModel.swift in Sources */,
 				B89CD69A2509944200D7D8ED /* MockCards.swift in Sources */,
 				B82AF5FD2548031F00FAB2A8 /* SearchBar.swift in Sources */,
@@ -880,6 +897,7 @@
 				B8A5E50E2527BACE003BCF07 /* UtilsTests.swift in Sources */,
 				B8D456B42508D1A2000F9E5F /* DictionaryParserTests.swift in Sources */,
 				B846482F2526CB5000D5A76D /* DictionaryFetcherTests.swift in Sources */,
+				B82E950E256673D5004A6F85 /* DeinflectorTests.swift in Sources */,
 				B8981108250F6D140059F71F /* Reed.xcdatamodeld in Sources */,
 				B8939B8425152ED0000399E0 /* DictionaryParserTestUtils.swift in Sources */,
 				B89810FA250F504E0059F71F /* TestUtils.swift in Sources */,

--- a/Reed.xcodeproj/project.pbxproj
+++ b/Reed.xcodeproj/project.pbxproj
@@ -3,16 +3,15 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 50;
+	objectVersion = 51;
 	objects = {
 
 /* Begin PBXBuildFile section */
-		373DE8EC873977020586BA5D /* libPods-Reed.a in Frameworks */ = {isa = PBXBuildFile; fileRef = DB226BA52A6687FA59B7D4F0 /* libPods-Reed.a */; };
 		6D4F99942551619300CC0DF6 /* TextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D4F99932551619300CC0DF6 /* TextView.swift */; };
 		6D4F99992551620200CC0DF6 /* DefinitionViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D4F99982551620200CC0DF6 /* DefinitionViewModel.swift */; };
 		6D4F99B82556A0C900CC0DF6 /* BottomSheetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D4F99B72556A0C900CC0DF6 /* BottomSheetView.swift */; };
 		6DCF77DB252DB19B00CB3C5D /* ReaderViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DCF77DA252DB19B00CB3C5D /* ReaderViewModel.swift */; };
-		A1D4D71735522B095DE86972 /* libPods-ReedTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = CB34B8D1D66FEC309309B5A6 /* libPods-ReedTests.a */; };
+		B2C716B87034AEAD96CF6D9F /* libPods-ReedTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = C6A22C103DD56D3BAC26C4B4 /* libPods-ReedTests.a */; };
 		B8093DD6251A988200D95DCF /* NotificationName+DictionaryParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8093DD5251A988200D95DCF /* NotificationName+DictionaryParser.swift */; };
 		B80CBD272542887700C807CD /* DiscoverListItemViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B80CBD262542887700C807CD /* DiscoverListItemViewModel.swift */; };
 		B80E0E6B25497E13009B0EE8 /* SearchResults.swift in Sources */ = {isa = PBXBuildFile; fileRef = B80E0E6A25497E13009B0EE8 /* SearchResults.swift */; };
@@ -22,7 +21,6 @@
 		B81C86FD250A1370000B9E5F /* LibraryViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B81C86FC250A1370000B9E5F /* LibraryViewModel.swift */; };
 		B81C86FF250A2207000B9E5F /* LibraryEntryViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B81C86FE250A2207000B9E5F /* LibraryEntryViewModel.swift */; };
 		B81C8702250A3675000B9E5F /* MockLibraryEntryData.swift in Sources */ = {isa = PBXBuildFile; fileRef = B81C8701250A3675000B9E5F /* MockLibraryEntryData.swift */; };
-		B82AF5DE2548015B00FAB2A8 /* (null) in Sources */ = {isa = PBXBuildFile; };
 		B82AF5DF2548015B00FAB2A8 /* View+UIKitComponents.swift in Sources */ = {isa = PBXBuildFile; fileRef = B82AF5DC2548015B00FAB2A8 /* View+UIKitComponents.swift */; };
 		B82AF5FD2548031F00FAB2A8 /* SearchBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = B82AF5FB2548031F00FAB2A8 /* SearchBar.swift */; };
 		B82AF5FE2548031F00FAB2A8 /* ViewControllerResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = B82AF5FC2548031F00FAB2A8 /* ViewControllerResolver.swift */; };
@@ -66,6 +64,7 @@
 		B8D456B42508D1A2000F9E5F /* DictionaryParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8D456B32508D1A2000F9E5F /* DictionaryParserTests.swift */; };
 		B8D456BF2508D1A3000F9E5F /* ReedUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8D456BE2508D1A3000F9E5F /* ReedUITests.swift */; };
 		B8D456D62508DD24000F9E5F /* LibraryEntryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8D456D52508DD24000F9E5F /* LibraryEntryView.swift */; };
+		B8E25B8825661B7A007B492E /* MecabWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8E25B8725661B7A007B492E /* MecabWrapper.swift */; };
 		B8F04A892517F07500405599 /* SplashView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8F04A882517F07500405599 /* SplashView.swift */; };
 		B8F5C20D250EDDB2000810F8 /* DictionaryEntry+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8F5C209250EDDB2000810F8 /* DictionaryEntry+CoreDataClass.swift */; };
 		B8F5C20E250EDDB2000810F8 /* DictionaryEntry+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8F5C20A250EDDB2000810F8 /* DictionaryEntry+CoreDataProperties.swift */; };
@@ -79,6 +78,7 @@
 		B8FA93B1254BAEEC00AE362C /* NovelDetailsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8FA93B0254BAEEC00AE362C /* NovelDetailsViewModel.swift */; };
 		B8FA93B9254BB08F00AE362C /* NovelDetailsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8FA93B8254BB08F00AE362C /* NovelDetailsView.swift */; };
 		B8FA93BE254BBE0D00AE362C /* NavigationLazyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8FA93BD254BBE0D00AE362C /* NavigationLazyView.swift */; };
+		F5417F397D38CDF2ADA7D622 /* libPods-Reed.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 94F3E3D17D6E8ABD1BBAC599 /* libPods-Reed.a */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -106,6 +106,7 @@
 		6D4F99982551620200CC0DF6 /* DefinitionViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefinitionViewModel.swift; sourceTree = "<group>"; };
 		6D4F99B72556A0C900CC0DF6 /* BottomSheetView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomSheetView.swift; sourceTree = "<group>"; };
 		6DCF77DA252DB19B00CB3C5D /* ReaderViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderViewModel.swift; sourceTree = "<group>"; };
+		94F3E3D17D6E8ABD1BBAC599 /* libPods-Reed.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Reed.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		B8093DD5251A988200D95DCF /* NotificationName+DictionaryParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NotificationName+DictionaryParser.swift"; sourceTree = "<group>"; };
 		B80CBD262542887700C807CD /* DiscoverListItemViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscoverListItemViewModel.swift; sourceTree = "<group>"; };
 		B80E0E6A25497E13009B0EE8 /* SearchResults.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SearchResults.swift; sourceTree = "<group>"; };
@@ -164,6 +165,8 @@
 		B8D456C02508D1A3000F9E5F /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		B8D456D52508DD24000F9E5F /* LibraryEntryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryEntryView.swift; sourceTree = "<group>"; };
 		B8D91017B089018BE0AEBA19 /* Pods-Reed.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Reed.debug.xcconfig"; path = "Target Support Files/Pods-Reed/Pods-Reed.debug.xcconfig"; sourceTree = "<group>"; };
+		B8E25B8725661B7A007B492E /* MecabWrapper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MecabWrapper.swift; sourceTree = "<group>"; };
+		B8E25B8C25661B97007B492E /* Reed-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Reed-Bridging-Header.h"; sourceTree = "<group>"; };
 		B8F04A882517F07500405599 /* SplashView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplashView.swift; sourceTree = "<group>"; };
 		B8F5C209250EDDB2000810F8 /* DictionaryEntry+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DictionaryEntry+CoreDataClass.swift"; sourceTree = "<group>"; };
 		B8F5C20A250EDDB2000810F8 /* DictionaryEntry+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DictionaryEntry+CoreDataProperties.swift"; sourceTree = "<group>"; };
@@ -177,8 +180,7 @@
 		B8FA93B0254BAEEC00AE362C /* NovelDetailsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NovelDetailsViewModel.swift; sourceTree = "<group>"; };
 		B8FA93B8254BB08F00AE362C /* NovelDetailsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NovelDetailsView.swift; sourceTree = "<group>"; };
 		B8FA93BD254BBE0D00AE362C /* NavigationLazyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationLazyView.swift; sourceTree = "<group>"; };
-		CB34B8D1D66FEC309309B5A6 /* libPods-ReedTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-ReedTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		DB226BA52A6687FA59B7D4F0 /* libPods-Reed.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Reed.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		C6A22C103DD56D3BAC26C4B4 /* libPods-ReedTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-ReedTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -186,7 +188,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				373DE8EC873977020586BA5D /* libPods-Reed.a in Frameworks */,
+				F5417F397D38CDF2ADA7D622 /* libPods-Reed.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -194,7 +196,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				A1D4D71735522B095DE86972 /* libPods-ReedTests.a in Frameworks */,
+				B2C716B87034AEAD96CF6D9F /* libPods-ReedTests.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -211,8 +213,8 @@
 		11B445F670F7250173F5030B /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				DB226BA52A6687FA59B7D4F0 /* libPods-Reed.a */,
-				CB34B8D1D66FEC309309B5A6 /* libPods-ReedTests.a */,
+				94F3E3D17D6E8ABD1BBAC599 /* libPods-Reed.a */,
+				C6A22C103DD56D3BAC26C4B4 /* libPods-ReedTests.a */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -441,6 +443,7 @@
 				B8D456AA2508D1A2000F9E5F /* Info.plist */,
 				B8D456CC2508D2E3000F9E5F /* Main */,
 				B82AF5D92548015B00FAB2A8 /* Components */,
+				B8E25B8625661B7A007B492E /* Tokenizer */,
 				B8981109250F803F0059F71F /* Extensions */,
 				B8462307250AF4E4002358A0 /* Dictionary */,
 				B880D135251810C90097AF8D /* SplashScreen */,
@@ -490,6 +493,7 @@
 				B8D4569B2508D1A2000F9E5F /* SceneDelegate.swift */,
 				B8D456A22508D1A2000F9E5F /* Assets.xcassets */,
 				B8D4569D2508D1A2000F9E5F /* Reed.xcdatamodeld */,
+				B8E25B8C25661B97007B492E /* Reed-Bridging-Header.h */,
 			);
 			path = Main;
 			sourceTree = "<group>";
@@ -553,6 +557,14 @@
 			path = views;
 			sourceTree = "<group>";
 		};
+		B8E25B8625661B7A007B492E /* Tokenizer */ = {
+			isa = PBXGroup;
+			children = (
+				B8E25B8725661B7A007B492E /* MecabWrapper.swift */,
+			);
+			path = Tokenizer;
+			sourceTree = "<group>";
+		};
 		B8F5C219250EF78E000810F8 /* Dictionary */ = {
 			isa = PBXGroup;
 			children = (
@@ -601,6 +613,7 @@
 				B8D456922508D1A2000F9E5F /* Sources */,
 				B8D456932508D1A2000F9E5F /* Frameworks */,
 				B8D456942508D1A2000F9E5F /* Resources */,
+				52D36624D4AE9A6A24A902BD /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -660,6 +673,7 @@
 				TargetAttributes = {
 					B8D456952508D1A2000F9E5F = {
 						CreatedOnToolsVersion = 11.3.1;
+						LastSwiftMigration = 1210;
 					};
 					B8D456AE2508D1A2000F9E5F = {
 						CreatedOnToolsVersion = 11.3.1;
@@ -741,6 +755,23 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
+		52D36624D4AE9A6A24A902BD /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Reed/Pods-Reed-resources-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Copy Pods Resources";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Reed/Pods-Reed-resources-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Reed/Pods-Reed-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
 		87957500889C5C5980C40661 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -770,6 +801,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				B8E25B8825661B7A007B492E /* MecabWrapper.swift in Sources */,
 				B8F5C20E250EDDB2000810F8 /* DictionaryEntry+CoreDataProperties.swift in Sources */,
 				B8F5C20F250EDDB2000810F8 /* DictionaryReading+CoreDataClass.swift in Sources */,
 				B80E0E6B25497E13009B0EE8 /* SearchResults.swift in Sources */,
@@ -810,7 +842,6 @@
 				B82AF65E2548187200FAB2A8 /* DiscoverSearchViewModel.swift in Sources */,
 				6D4F99942551619300CC0DF6 /* TextView.swift in Sources */,
 				B89CD6962509938C00D7D8ED /* VocabularyCardView.swift in Sources */,
-				B82AF5DE2548015B00FAB2A8 /* (null) in Sources */,
 				B82AF6472548148200FAB2A8 /* SearchHistory.swift in Sources */,
 				B89810F8250F17210059F71F /* DictionaryStorageManager.swift in Sources */,
 				6DCF77DB252DB19B00CB3C5D /* ReaderViewModel.swift in Sources */,
@@ -991,6 +1022,7 @@
 			baseConfigurationReference = B8D91017B089018BE0AEBA19 /* Pods-Reed.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_ASSET_PATHS = "\"Reed/Preview Content\"";
 				DEVELOPMENT_TEAM = "";
@@ -1002,6 +1034,8 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = Reed.Reed;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OBJC_BRIDGING_HEADER = "Reed/Main/Reed-Bridging-Header.h";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
@@ -1012,6 +1046,7 @@
 			baseConfigurationReference = 05F6AF7D4822634DEDD39684 /* Pods-Reed.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_ASSET_PATHS = "\"Reed/Preview Content\"";
 				DEVELOPMENT_TEAM = "";
@@ -1023,6 +1058,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = Reed.Reed;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OBJC_BRIDGING_HEADER = "Reed/Main/Reed-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
@@ -1036,7 +1072,7 @@
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
 				INFOPLIST_FILE = ReedTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 13.2;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1058,7 +1094,7 @@
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
 				INFOPLIST_FILE = ReedTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 13.2;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/Reed.xcodeproj/project.pbxproj
+++ b/Reed.xcodeproj/project.pbxproj
@@ -11,8 +11,8 @@
 		6D4F99992551620200CC0DF6 /* DefinitionViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D4F99982551620200CC0DF6 /* DefinitionViewModel.swift */; };
 		6D4F99B82556A0C900CC0DF6 /* BottomSheetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D4F99B72556A0C900CC0DF6 /* BottomSheetView.swift */; };
 		6DCF77DB252DB19B00CB3C5D /* ReaderViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DCF77DA252DB19B00CB3C5D /* ReaderViewModel.swift */; };
+		8AFA1B8EBEB7590252ECB58B /* libPods-ReedTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 7FED962AB0C24D51C5D53286 /* libPods-ReedTests.a */; };
 		AB7A1C88AECCC47C55B834C9 /* libPods-Reed.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 94F3E3D17D6E8ABD1BBAC599 /* libPods-Reed.a */; };
-		B2C716B87034AEAD96CF6D9F /* libPods-ReedTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = C6A22C103DD56D3BAC26C4B4 /* libPods-ReedTests.a */; };
 		B8093DD6251A988200D95DCF /* NotificationName+DictionaryParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8093DD5251A988200D95DCF /* NotificationName+DictionaryParser.swift */; };
 		B80CBD272542887700C807CD /* DiscoverListItemViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B80CBD262542887700C807CD /* DiscoverListItemViewModel.swift */; };
 		B80E0E6B25497E13009B0EE8 /* SearchResults.swift in Sources */ = {isa = PBXBuildFile; fileRef = B80E0E6A25497E13009B0EE8 /* SearchResults.swift */; };
@@ -29,6 +29,7 @@
 		B82AF65E2548187200FAB2A8 /* DiscoverSearchViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B82AF65D2548187200FAB2A8 /* DiscoverSearchViewModel.swift */; };
 		B82D3D95254D2DA200F06836 /* CategoryButtons.swift in Sources */ = {isa = PBXBuildFile; fileRef = B82D3D94254D2DA200F06836 /* CategoryButtons.swift */; };
 		B82D3D9A254D2E7700F06836 /* CategoryButtonsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B82D3D99254D2E7700F06836 /* CategoryButtonsViewModel.swift */; };
+		B82E949325662E98004A6F85 /* PartOfSpeech.swift in Sources */ = {isa = PBXBuildFile; fileRef = B82E949225662E98004A6F85 /* PartOfSpeech.swift */; };
 		B8462309250AF5A3002358A0 /* DictionaryParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8462308250AF5A3002358A0 /* DictionaryParser.swift */; };
 		B846482F2526CB5000D5A76D /* DictionaryFetcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B846482E2526CB5000D5A76D /* DictionaryFetcherTests.swift */; };
 		B8539EE52519755A000FF025 /* DictionaryStorageManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8539EE42519755A000FF025 /* DictionaryStorageManagerTests.swift */; };
@@ -39,7 +40,7 @@
 		B87D30782516C537002E25FF /* DictionaryLanguageSource+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = B87D30762516C537002E25FF /* DictionaryLanguageSource+CoreDataProperties.swift */; };
 		B880D139251810F20097AF8D /* SplashViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B880D138251810F20097AF8D /* SplashViewModel.swift */; };
 		B8939B8425152ED0000399E0 /* DictionaryParserTestUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8939B8325152ED0000399E0 /* DictionaryParserTestUtils.swift */; };
-		B89778D12566233600DF1B79 /* MecabWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = B89778D02566233600DF1B79 /* MecabWrapper.swift */; };
+		B8977925256626D400DF1B79 /* MecabWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8977923256626D400DF1B79 /* MecabWrapper.swift */; };
 		B89810F8250F17210059F71F /* DictionaryStorageManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B89810F7250F17210059F71F /* DictionaryStorageManager.swift */; };
 		B89810FA250F504E0059F71F /* TestUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = B89810F9250F504E0059F71F /* TestUtils.swift */; };
 		B8981108250F6D140059F71F /* Reed.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = B8D4569D2508D1A2000F9E5F /* Reed.xcdatamodeld */; };
@@ -66,8 +67,6 @@
 		B8D456B42508D1A2000F9E5F /* DictionaryParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8D456B32508D1A2000F9E5F /* DictionaryParserTests.swift */; };
 		B8D456BF2508D1A3000F9E5F /* ReedUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8D456BE2508D1A3000F9E5F /* ReedUITests.swift */; };
 		B8D456D62508DD24000F9E5F /* LibraryEntryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8D456D52508DD24000F9E5F /* LibraryEntryView.swift */; };
-		B8E25B8825661B7A007B492E /* MecabWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8E25B8725661B7A007B492E /* MecabWrapper.swift */; };
-		B8D456D82508DD46000F9E5F /* MockBooks.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8D456D72508DD46000F9E5F /* MockBooks.swift */; };
 		B8F04A892517F07500405599 /* SplashView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8F04A882517F07500405599 /* SplashView.swift */; };
 		B8F5C20D250EDDB2000810F8 /* DictionaryEntry+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8F5C209250EDDB2000810F8 /* DictionaryEntry+CoreDataClass.swift */; };
 		B8F5C20E250EDDB2000810F8 /* DictionaryEntry+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8F5C20A250EDDB2000810F8 /* DictionaryEntry+CoreDataProperties.swift */; };
@@ -81,7 +80,6 @@
 		B8FA93B1254BAEEC00AE362C /* NovelDetailsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8FA93B0254BAEEC00AE362C /* NovelDetailsViewModel.swift */; };
 		B8FA93B9254BB08F00AE362C /* NovelDetailsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8FA93B8254BB08F00AE362C /* NovelDetailsView.swift */; };
 		B8FA93BE254BBE0D00AE362C /* NavigationLazyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8FA93BD254BBE0D00AE362C /* NavigationLazyView.swift */; };
-		F5417F397D38CDF2ADA7D622 /* libPods-Reed.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 94F3E3D17D6E8ABD1BBAC599 /* libPods-Reed.a */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -109,6 +107,7 @@
 		6D4F99982551620200CC0DF6 /* DefinitionViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefinitionViewModel.swift; sourceTree = "<group>"; };
 		6D4F99B72556A0C900CC0DF6 /* BottomSheetView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomSheetView.swift; sourceTree = "<group>"; };
 		6DCF77DA252DB19B00CB3C5D /* ReaderViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderViewModel.swift; sourceTree = "<group>"; };
+		7FED962AB0C24D51C5D53286 /* libPods-ReedTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-ReedTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		94F3E3D17D6E8ABD1BBAC599 /* libPods-Reed.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Reed.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		B8093DD5251A988200D95DCF /* NotificationName+DictionaryParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NotificationName+DictionaryParser.swift"; sourceTree = "<group>"; };
 		B80CBD262542887700C807CD /* DiscoverListItemViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscoverListItemViewModel.swift; sourceTree = "<group>"; };
@@ -126,6 +125,7 @@
 		B82AF65D2548187200FAB2A8 /* DiscoverSearchViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscoverSearchViewModel.swift; sourceTree = "<group>"; };
 		B82D3D94254D2DA200F06836 /* CategoryButtons.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryButtons.swift; sourceTree = "<group>"; };
 		B82D3D99254D2E7700F06836 /* CategoryButtonsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryButtonsViewModel.swift; sourceTree = "<group>"; };
+		B82E949225662E98004A6F85 /* PartOfSpeech.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PartOfSpeech.swift; sourceTree = "<group>"; };
 		B8462308250AF5A3002358A0 /* DictionaryParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictionaryParser.swift; sourceTree = "<group>"; };
 		B846482E2526CB5000D5A76D /* DictionaryFetcherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictionaryFetcherTests.swift; sourceTree = "<group>"; };
 		B8539EE42519755A000FF025 /* DictionaryStorageManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictionaryStorageManagerTests.swift; sourceTree = "<group>"; };
@@ -136,7 +136,7 @@
 		B87D30762516C537002E25FF /* DictionaryLanguageSource+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DictionaryLanguageSource+CoreDataProperties.swift"; sourceTree = "<group>"; };
 		B880D138251810F20097AF8D /* SplashViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplashViewModel.swift; sourceTree = "<group>"; };
 		B8939B8325152ED0000399E0 /* DictionaryParserTestUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictionaryParserTestUtils.swift; sourceTree = "<group>"; };
-		B89778D02566233600DF1B79 /* MecabWrapper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MecabWrapper.swift; sourceTree = "<group>"; };
+		B8977923256626D400DF1B79 /* MecabWrapper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MecabWrapper.swift; sourceTree = "<group>"; };
 		B89810F7250F17210059F71F /* DictionaryStorageManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictionaryStorageManager.swift; sourceTree = "<group>"; };
 		B89810F9250F504E0059F71F /* TestUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestUtils.swift; sourceTree = "<group>"; };
 		B898110A250F81600059F71F /* NSManagedObject+Init.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSManagedObject+Init.swift"; sourceTree = "<group>"; };
@@ -183,7 +183,6 @@
 		B8FA93B0254BAEEC00AE362C /* NovelDetailsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NovelDetailsViewModel.swift; sourceTree = "<group>"; };
 		B8FA93B8254BB08F00AE362C /* NovelDetailsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NovelDetailsView.swift; sourceTree = "<group>"; };
 		B8FA93BD254BBE0D00AE362C /* NavigationLazyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationLazyView.swift; sourceTree = "<group>"; };
-		C6A22C103DD56D3BAC26C4B4 /* libPods-ReedTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-ReedTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -199,7 +198,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				B2C716B87034AEAD96CF6D9F /* libPods-ReedTests.a in Frameworks */,
+				8AFA1B8EBEB7590252ECB58B /* libPods-ReedTests.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -217,7 +216,7 @@
 			isa = PBXGroup;
 			children = (
 				94F3E3D17D6E8ABD1BBAC599 /* libPods-Reed.a */,
-				C6A22C103DD56D3BAC26C4B4 /* libPods-ReedTests.a */,
+				7FED962AB0C24D51C5D53286 /* libPods-ReedTests.a */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -339,10 +338,11 @@
 			path = SplashScreen;
 			sourceTree = "<group>";
 		};
-		B89778CF2566233600DF1B79 /* Tokenizer */ = {
+		B8977921256626D400DF1B79 /* Tokenizer */ = {
 			isa = PBXGroup;
 			children = (
-				B89778D02566233600DF1B79 /* MecabWrapper.swift */,
+				B8977923256626D400DF1B79 /* MecabWrapper.swift */,
+				B82E949225662E98004A6F85 /* PartOfSpeech.swift */,
 			);
 			path = Tokenizer;
 			sourceTree = "<group>";
@@ -454,7 +454,7 @@
 				B8D456AA2508D1A2000F9E5F /* Info.plist */,
 				B8D456CC2508D2E3000F9E5F /* Main */,
 				B82AF5D92548015B00FAB2A8 /* Components */,
-				B89778CF2566233600DF1B79 /* Tokenizer */,
+				B8977921256626D400DF1B79 /* Tokenizer */,
 				B880D135251810C90097AF8D /* SplashScreen */,
 				B8981109250F803F0059F71F /* Extensions */,
 				B8462307250AF4E4002358A0 /* Dictionary */,
@@ -567,14 +567,6 @@
 				B8D456A02508D1A2000F9E5F /* LibraryView.swift */,
 			);
 			path = views;
-			sourceTree = "<group>";
-		};
-		B8D456D42508DCC7000F9E5F /* models */ = {
-			isa = PBXGroup;
-			children = (
-				B8D456D72508DD46000F9E5F /* MockBooks.swift */,
-			);
-			path = models;
 			sourceTree = "<group>";
 		};
 		B8F5C219250EF78E000810F8 /* Dictionary */ = {
@@ -813,7 +805,6 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				B89778D12566233600DF1B79 /* MecabWrapper.swift in Sources */,
 				B8F5C20E250EDDB2000810F8 /* DictionaryEntry+CoreDataProperties.swift in Sources */,
 				B8F5C20F250EDDB2000810F8 /* DictionaryReading+CoreDataClass.swift in Sources */,
 				B80E0E6B25497E13009B0EE8 /* SearchResults.swift in Sources */,
@@ -863,6 +854,8 @@
 				B89CD698250993F800D7D8ED /* DefinitionView.swift in Sources */,
 				B82D3D95254D2DA200F06836 /* CategoryButtons.swift in Sources */,
 				B8A78F072542F26700577974 /* DiscoverList.swift in Sources */,
+				B82E949325662E98004A6F85 /* PartOfSpeech.swift in Sources */,
+				B89CD698250993F800D7D8ED /* DefinitionView.swift in Sources */,
 				B81C86FF250A2207000B9E5F /* LibraryEntryViewModel.swift in Sources */,
 				B89CD69A2509944200D7D8ED /* MockCards.swift in Sources */,
 				B82AF5FD2548031F00FAB2A8 /* SearchBar.swift in Sources */,
@@ -871,6 +864,7 @@
 				B81C8702250A3675000B9E5F /* MockLibraryEntryData.swift in Sources */,
 				B8D4569C2508D1A2000F9E5F /* SceneDelegate.swift in Sources */,
 				B81C86FD250A1370000B9E5F /* LibraryViewModel.swift in Sources */,
+				B8977925256626D400DF1B79 /* MecabWrapper.swift in Sources */,
 				B8F5C20D250EDDB2000810F8 /* DictionaryEntry+CoreDataClass.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Reed.xcodeproj/project.pbxproj
+++ b/Reed.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		6D4F99942551619300CC0DF6 /* TextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D4F99932551619300CC0DF6 /* TextView.swift */; };
 		6D4F99992551620200CC0DF6 /* DefinitionViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D4F99982551620200CC0DF6 /* DefinitionViewModel.swift */; };
 		6D4F99B82556A0C900CC0DF6 /* BottomSheetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D4F99B72556A0C900CC0DF6 /* BottomSheetView.swift */; };
+		535DAAFAD261F3FD515DE20D /* libPods-ReedTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 2B202909C8BC7C48879B3AFF /* libPods-ReedTests.a */; };
 		6DCF77DB252DB19B00CB3C5D /* ReaderViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DCF77DA252DB19B00CB3C5D /* ReaderViewModel.swift */; };
 		8AFA1B8EBEB7590252ECB58B /* libPods-ReedTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 7FED962AB0C24D51C5D53286 /* libPods-ReedTests.a */; };
 		AB7A1C88AECCC47C55B834C9 /* libPods-Reed.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 94F3E3D17D6E8ABD1BBAC599 /* libPods-Reed.a */; };
@@ -33,10 +34,12 @@
 		B82E94A42566332D004A6F85 /* MecabWordNode.swift in Sources */ = {isa = PBXBuildFile; fileRef = B82E94A32566332D004A6F85 /* MecabWordNode.swift */; };
 		B82E94AD25663890004A6F85 /* Deinflector.swift in Sources */ = {isa = PBXBuildFile; fileRef = B82E94AB25663890004A6F85 /* Deinflector.swift */; };
 		B82E94AE25663890004A6F85 /* DeinflectionRules.swift in Sources */ = {isa = PBXBuildFile; fileRef = B82E94AC25663890004A6F85 /* DeinflectionRules.swift */; };
-		B82E950E256673D5004A6F85 /* DeinflectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B82E950D256673D5004A6F85 /* DeinflectorTests.swift */; };
 		B82E94B3256643C2004A6F85 /* Tokenizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B82E94B2256643C2004A6F85 /* Tokenizer.swift */; };
 		B82E94B825664EA0004A6F85 /* FuriganaMaker.swift in Sources */ = {isa = PBXBuildFile; fileRef = B82E94B725664EA0004A6F85 /* FuriganaMaker.swift */; };
 		B82E94BD25665601004A6F85 /* PartOfSpeechMatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = B82E94BC25665601004A6F85 /* PartOfSpeechMatcher.swift */; };
+		B82E94CA256658A8004A6F85 /* FuriganaMakerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B82E94C6256658A8004A6F85 /* FuriganaMakerTests.swift */; };
+		B82E94CB256658A8004A6F85 /* TokenizerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B82E94C7256658A8004A6F85 /* TokenizerTests.swift */; };
+		B82E94CC256658A8004A6F85 /* PartOfSpeechMatcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B82E94C8256658A8004A6F85 /* PartOfSpeechMatcherTests.swift */; };
 		B8462309250AF5A3002358A0 /* DictionaryParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8462308250AF5A3002358A0 /* DictionaryParser.swift */; };
 		B846482F2526CB5000D5A76D /* DictionaryFetcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B846482E2526CB5000D5A76D /* DictionaryFetcherTests.swift */; };
 		B8465D3E2566FD0C00967841 /* DefinitionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8465D3D2566FD0C00967841 /* DefinitionView.swift */; };
@@ -65,6 +68,7 @@
 		B8A78F072542F26700577974 /* DiscoverList.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8A78F062542F26700577974 /* DiscoverList.swift */; };
 		B8A78F0C2542F27200577974 /* DiscoverListItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8A78F0B2542F27200577974 /* DiscoverListItem.swift */; };
 		B8B8F9912526C10400D6DF8B /* DictionaryFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8B8F9902526C10400D6DF8B /* DictionaryFetcher.swift */; };
+		B8D041C125667C18003F1E05 /* DeinflectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8D041C025667C18003F1E05 /* DeinflectorTests.swift */; };
 		B8D4569A2508D1A2000F9E5F /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8D456992508D1A2000F9E5F /* AppDelegate.swift */; };
 		B8D4569C2508D1A2000F9E5F /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8D4569B2508D1A2000F9E5F /* SceneDelegate.swift */; };
 		B8D4569F2508D1A2000F9E5F /* Reed.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = B8D4569D2508D1A2000F9E5F /* Reed.xcdatamodeld */; };
@@ -109,6 +113,7 @@
 /* Begin PBXFileReference section */
 		05F6AF7D4822634DEDD39684 /* Pods-Reed.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Reed.release.xcconfig"; path = "Target Support Files/Pods-Reed/Pods-Reed.release.xcconfig"; sourceTree = "<group>"; };
 		09D60999940D335A7D74D917 /* Pods-ReedTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ReedTests.debug.xcconfig"; path = "Target Support Files/Pods-ReedTests/Pods-ReedTests.debug.xcconfig"; sourceTree = "<group>"; };
+		2B202909C8BC7C48879B3AFF /* libPods-ReedTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-ReedTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		4C9134A1E97C7A555EA7B8DB /* Pods-ReedTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ReedTests.release.xcconfig"; path = "Target Support Files/Pods-ReedTests/Pods-ReedTests.release.xcconfig"; sourceTree = "<group>"; };
 		6D4F99932551619300CC0DF6 /* TextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextView.swift; sourceTree = "<group>"; };
 		6D4F99982551620200CC0DF6 /* DefinitionViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefinitionViewModel.swift; sourceTree = "<group>"; };
@@ -136,10 +141,12 @@
 		B82E94A32566332D004A6F85 /* MecabWordNode.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MecabWordNode.swift; sourceTree = "<group>"; };
 		B82E94AB25663890004A6F85 /* Deinflector.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Deinflector.swift; sourceTree = "<group>"; };
 		B82E94AC25663890004A6F85 /* DeinflectionRules.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DeinflectionRules.swift; sourceTree = "<group>"; };
-		B82E950D256673D5004A6F85 /* DeinflectorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DeinflectorTests.swift; sourceTree = "<group>"; };
 		B82E94B2256643C2004A6F85 /* Tokenizer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Tokenizer.swift; sourceTree = "<group>"; };
 		B82E94B725664EA0004A6F85 /* FuriganaMaker.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FuriganaMaker.swift; sourceTree = "<group>"; };
 		B82E94BC25665601004A6F85 /* PartOfSpeechMatcher.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PartOfSpeechMatcher.swift; sourceTree = "<group>"; };
+		B82E94C6256658A8004A6F85 /* FuriganaMakerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FuriganaMakerTests.swift; sourceTree = "<group>"; };
+		B82E94C7256658A8004A6F85 /* TokenizerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TokenizerTests.swift; sourceTree = "<group>"; };
+		B82E94C8256658A8004A6F85 /* PartOfSpeechMatcherTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PartOfSpeechMatcherTests.swift; sourceTree = "<group>"; };
 		B8462308250AF5A3002358A0 /* DictionaryParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictionaryParser.swift; sourceTree = "<group>"; };
 		B846482E2526CB5000D5A76D /* DictionaryFetcherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictionaryFetcherTests.swift; sourceTree = "<group>"; };
 		B8465D3D2566FD0C00967841 /* DefinitionView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DefinitionView.swift; sourceTree = "<group>"; };
@@ -167,6 +174,7 @@
 		B8A78F062542F26700577974 /* DiscoverList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscoverList.swift; sourceTree = "<group>"; };
 		B8A78F0B2542F27200577974 /* DiscoverListItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscoverListItem.swift; sourceTree = "<group>"; };
 		B8B8F9902526C10400D6DF8B /* DictionaryFetcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictionaryFetcher.swift; sourceTree = "<group>"; };
+		B8D041C025667C18003F1E05 /* DeinflectorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DeinflectorTests.swift; sourceTree = "<group>"; };
 		B8D456962508D1A2000F9E5F /* Reed.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Reed.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		B8D456992508D1A2000F9E5F /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		B8D4569B2508D1A2000F9E5F /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -213,6 +221,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				8AFA1B8EBEB7590252ECB58B /* libPods-ReedTests.a in Frameworks */,
+				535DAAFAD261F3FD515DE20D /* libPods-ReedTests.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -231,6 +240,7 @@
 			children = (
 				94F3E3D17D6E8ABD1BBAC599 /* libPods-Reed.a */,
 				7FED962AB0C24D51C5D53286 /* libPods-ReedTests.a */,
+				2B202909C8BC7C48879B3AFF /* libPods-ReedTests.a */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -312,13 +322,17 @@
 			path = views;
 			sourceTree = "<group>";
 		};
-		B82E950C256673D5004A6F85 /* Tokenizer */ = {
+		B82E94C4256658A8004A6F85 /* Tokenizer */ = {
 			isa = PBXGroup;
 			children = (
-				B82E950D256673D5004A6F85 /* DeinflectorTests.swift */,
+				B8D041C025667C18003F1E05 /* DeinflectorTests.swift */,
+				B82E94C6256658A8004A6F85 /* FuriganaMakerTests.swift */,
+				B82E94C7256658A8004A6F85 /* TokenizerTests.swift */,
+				B82E94C8256658A8004A6F85 /* PartOfSpeechMatcherTests.swift */,
 			);
-			path = Tokenizer;
-			sourceTree = "<group>";
+			name = Tokenizer;
+			path = ReedTests/Tokenizer;
+			sourceTree = SOURCE_ROOT;
 		};
 		B8462307250AF4E4002358A0 /* Dictionary */ = {
 			isa = PBXGroup;
@@ -508,7 +522,7 @@
 		B8D456B22508D1A2000F9E5F /* ReedTests */ = {
 			isa = PBXGroup;
 			children = (
-				B82E950C256673D5004A6F85 /* Tokenizer */,
+				B82E94C4256658A8004A6F85 /* Tokenizer */,
 				B8F5C219250EF78E000810F8 /* Dictionary */,
 				B8D456B52508D1A2000F9E5F /* Info.plist */,
 				B89810F9250F504E0059F71F /* TestUtils.swift */,
@@ -906,13 +920,16 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				B82E94CA256658A8004A6F85 /* FuriganaMakerTests.swift in Sources */,
+				B82E94CC256658A8004A6F85 /* PartOfSpeechMatcherTests.swift in Sources */,
 				B8A5E50E2527BACE003BCF07 /* UtilsTests.swift in Sources */,
 				B8D456B42508D1A2000F9E5F /* DictionaryParserTests.swift in Sources */,
 				B846482F2526CB5000D5A76D /* DictionaryFetcherTests.swift in Sources */,
-				B82E950E256673D5004A6F85 /* DeinflectorTests.swift in Sources */,
 				B8981108250F6D140059F71F /* Reed.xcdatamodeld in Sources */,
 				B8939B8425152ED0000399E0 /* DictionaryParserTestUtils.swift in Sources */,
+				B82E94CB256658A8004A6F85 /* TokenizerTests.swift in Sources */,
 				B89810FA250F504E0059F71F /* TestUtils.swift in Sources */,
+				B8D041C125667C18003F1E05 /* DeinflectorTests.swift in Sources */,
 				B8539EE52519755A000FF025 /* DictionaryStorageManagerTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Reed.xcodeproj/project.pbxproj
+++ b/Reed.xcodeproj/project.pbxproj
@@ -36,6 +36,7 @@
 		B82E950E256673D5004A6F85 /* DeinflectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B82E950D256673D5004A6F85 /* DeinflectorTests.swift */; };
 		B82E94B3256643C2004A6F85 /* Tokenizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B82E94B2256643C2004A6F85 /* Tokenizer.swift */; };
 		B82E94B825664EA0004A6F85 /* FuriganaMaker.swift in Sources */ = {isa = PBXBuildFile; fileRef = B82E94B725664EA0004A6F85 /* FuriganaMaker.swift */; };
+		B82E94BD25665601004A6F85 /* PartOfSpeechMatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = B82E94BC25665601004A6F85 /* PartOfSpeechMatcher.swift */; };
 		B8462309250AF5A3002358A0 /* DictionaryParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8462308250AF5A3002358A0 /* DictionaryParser.swift */; };
 		B846482F2526CB5000D5A76D /* DictionaryFetcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B846482E2526CB5000D5A76D /* DictionaryFetcherTests.swift */; };
 		B8465D3E2566FD0C00967841 /* DefinitionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8465D3D2566FD0C00967841 /* DefinitionView.swift */; };
@@ -138,6 +139,7 @@
 		B82E950D256673D5004A6F85 /* DeinflectorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DeinflectorTests.swift; sourceTree = "<group>"; };
 		B82E94B2256643C2004A6F85 /* Tokenizer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Tokenizer.swift; sourceTree = "<group>"; };
 		B82E94B725664EA0004A6F85 /* FuriganaMaker.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FuriganaMaker.swift; sourceTree = "<group>"; };
+		B82E94BC25665601004A6F85 /* PartOfSpeechMatcher.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PartOfSpeechMatcher.swift; sourceTree = "<group>"; };
 		B8462308250AF5A3002358A0 /* DictionaryParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictionaryParser.swift; sourceTree = "<group>"; };
 		B846482E2526CB5000D5A76D /* DictionaryFetcherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictionaryFetcherTests.swift; sourceTree = "<group>"; };
 		B8465D3D2566FD0C00967841 /* DefinitionView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DefinitionView.swift; sourceTree = "<group>"; };
@@ -361,6 +363,7 @@
 		B8977921256626D400DF1B79 /* Tokenizer */ = {
 			isa = PBXGroup;
 			children = (
+				B82E94BC25665601004A6F85 /* PartOfSpeechMatcher.swift */,
 				B82E94B725664EA0004A6F85 /* FuriganaMaker.swift */,
 				B82E94B2256643C2004A6F85 /* Tokenizer.swift */,
 				B82E94AC25663890004A6F85 /* DeinflectionRules.swift */,
@@ -846,6 +849,7 @@
 				B8FA93B9254BB08F00AE362C /* NovelDetailsView.swift in Sources */,
 				6D4F99992551620200CC0DF6 /* DefinitionViewModel.swift in Sources */,
 				B8F5C210250EDDB2000810F8 /* DictionaryReading+CoreDataProperties.swift in Sources */,
+				B82E94BD25665601004A6F85 /* PartOfSpeechMatcher.swift in Sources */,
 				B8A2617F25268B5C00A2FBFD /* Utils.swift in Sources */,
 				B80F45BC25411271004F8A22 /* DiscoverListViewModel.swift in Sources */,
 				B880D139251810F20097AF8D /* SplashViewModel.swift in Sources */,

--- a/Reed/Main/Reed-Bridging-Header.h
+++ b/Reed/Main/Reed-Bridging-Header.h
@@ -1,0 +1,6 @@
+//
+//  Use this file to import your target's public headers that you would like to expose to Swift.
+//
+
+#import <mecab-ko/MecabObjC.h>
+#import <mecab-ko/MecabNode.h>

--- a/Reed/Main/Reed.xcdatamodeld/Reed.xcdatamodel/contents
+++ b/Reed/Main/Reed.xcdatamodeld/Reed.xcdatamodel/contents
@@ -31,12 +31,18 @@
         <attribute name="readingTerms" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData" customClassName="[String]"/>
         <attribute name="readingUnusualInfo" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData" customClassName="[String]"/>
         <relationship name="readingParentEntry" maxCount="1" deletionRule="Nullify" destinationEntity="DictionaryEntry" inverseName="entryReadings" inverseEntity="DictionaryEntry"/>
+        <fetchIndex name="byPropertyIndex">
+            <fetchIndexElement property="readingReading" type="Binary" order="ascending"/>
+        </fetchIndex>
     </entity>
     <entity name="DictionaryTerm" representedClassName="DictionaryTerm" syncable="YES">
         <attribute name="termFrequencyPriorities" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData" customClassName="[String]"/>
         <attribute name="termTerm" attributeType="String"/>
         <attribute name="termUnusualInfo" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData" customClassName="[String]"/>
         <relationship name="termParentEntry" maxCount="1" deletionRule="Nullify" destinationEntity="DictionaryEntry" inverseName="entryTerms" inverseEntity="DictionaryEntry"/>
+        <fetchIndex name="byPropertyIndex">
+            <fetchIndexElement property="termTerm" type="Binary" order="ascending"/>
+        </fetchIndex>
     </entity>
     <entity name="LibraryEntry" representedClassName="LibraryEntry" syncable="YES" codeGenerationType="class">
         <attribute name="author" attributeType="String"/>

--- a/Reed/Tokenizer/DeinflectionRules.swift
+++ b/Reed/Tokenizer/DeinflectionRules.swift
@@ -1,0 +1,3409 @@
+//
+//  DeinflectionRules.swift
+//  Reed
+//
+//  Created by Shiori Yamashita on 2020/10/11.
+//  Copyright © 2020 Roger Luo. All rights reserved.
+//
+
+// These rules are taken from https://github.com/birtles/rikaichamp
+
+// A value of ConjugationGroup or a combination of multiple ConjugationGroup's
+typealias ConjugationGroupValue = UInt8
+
+struct Rule {
+    let source: String
+    let target: String
+    let sourceConjugationGroupValue: ConjugationGroupValue
+    let targetConjugationGroupValue: ConjugationGroupValue
+    let reason: DeinflectionReason
+}
+
+enum DeinflectionReason {
+    case Adv
+    case Ba
+    case Causative
+    case CausativePassive
+    case Chau
+    case Continuous
+    case Imperative
+    case ImperativeNegative
+    case MasuStem
+    case Nasai
+    case Negative
+    case Noun
+    case Passive
+    case Past
+    case Polite
+    case PoliteNegative
+    case PolitePast
+    case PolitePastNegative
+    case PoliteVolitional
+    case Potential
+    case PotentialOrPassive
+    case Sou
+    case Sugiru
+    case Tai
+    case Tara
+    case Tari
+    case Te
+    case Toku
+    case Volitional
+    case Zu
+}
+
+enum ConjugationGroup {
+    static let IchidanVerb: ConjugationGroupValue = 0b00000001
+    static let GodanVerb: ConjugationGroupValue = 0b00000010
+    static let IAdjective: ConjugationGroupValue = 0b00000100
+    static let KuruVerb: ConjugationGroupValue = 0b00001000
+    static let SuruVerb: ConjugationGroupValue = 0b00010000
+    
+    // Does not match the result of any deinflection, but matches the Anything type
+    static let NotResultOfAnyDeinflection: ConjugationGroupValue = 0b10000000
+    
+    // The initial state where the conjugation group of the word is unknown
+    static let Anything: ConjugationGroupValue = 0b11111111
+}
+
+let deinflectionRules = [
+    Rule(
+        source: "いらっしゃいませんでした",
+        target: "いらっしゃる",
+        sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+        targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+        reason: DeinflectionReason.PolitePastNegative
+    ),
+    Rule(
+      source: "おっしゃいませんでした",
+      target: "おっしゃる",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.PolitePastNegative
+    ),
+    Rule(
+      source: "いらっしゃいました",
+      target: "いらっしゃる",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.PolitePast
+    ),
+    Rule(
+      source: "くありませんでした",
+      target: "い",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.IAdjective,
+      reason: DeinflectionReason.PolitePastNegative
+    ),
+    Rule(
+      source: "いらっしゃいます",
+      target: "いらっしゃる",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Polite
+    ),
+    Rule(
+      source: "おっしゃいました",
+      target: "おっしゃる",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.PolitePast
+    ),
+    Rule(
+      source: "仰いませんでした",
+      target: "仰る",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.PolitePastNegative
+    ),
+    Rule(
+      source: "いませんでした",
+      target: "う",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.PolitePastNegative
+    ),
+    Rule(
+      source: "おっしゃいます",
+      target: "おっしゃる",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Polite
+    ),
+    Rule(
+      source: "きませんでした",
+      target: "く",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.PolitePastNegative
+    ),
+    Rule(
+      source: "きませんでした",
+      target: "くる",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.KuruVerb,
+      reason: DeinflectionReason.PolitePastNegative
+    ),
+    Rule(
+      source: "ぎませんでした",
+      target: "ぐ",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.PolitePastNegative
+    ),
+    Rule(
+      source: "しませんでした",
+      target: "す",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.PolitePastNegative
+    ),
+    Rule(
+      source: "しませんでした",
+      target: "する",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.SuruVerb,
+      reason: DeinflectionReason.PolitePastNegative
+    ),
+    Rule(
+      source: "ちませんでした",
+      target: "つ",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.PolitePastNegative
+    ),
+    Rule(
+      source: "にませんでした",
+      target: "ぬ",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.PolitePastNegative
+    ),
+    Rule(
+      source: "びませんでした",
+      target: "ぶ",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.PolitePastNegative
+    ),
+    Rule(
+      source: "みませんでした",
+      target: "む",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.PolitePastNegative
+    ),
+    Rule(
+      source: "りませんでした",
+      target: "る",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.PolitePastNegative
+    ),
+    Rule(
+      source: "いらっしゃい",
+      target: "いらっしゃる",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.MasuStem
+    ),
+    Rule(
+      source: "いらっしゃい",
+      target: "いらっしゃる",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Imperative
+    ),
+    Rule(
+      source: "くありません",
+      target: "い",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.IAdjective,
+      reason: DeinflectionReason.PoliteNegative
+    ),
+    Rule(
+      source: "ませんでした",
+      target: "る",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.IchidanVerb | ConjugationGroup.KuruVerb,
+      reason: DeinflectionReason.PolitePastNegative
+    ),
+    Rule(
+      source: "のたもうたら",
+      target: "のたまう",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Tara
+    ),
+    Rule(
+      source: "のたもうたり",
+      target: "のたまう",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Tari
+    ),
+    Rule(
+      source: "いましょう",
+      target: "う",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.PoliteVolitional
+    ),
+    Rule(
+      source: "仰いました",
+      target: "仰る",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.PolitePast
+    ),
+    Rule(
+      source: "おっしゃい",
+      target: "おっしゃる",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.MasuStem
+    ),
+    Rule(
+      source: "おっしゃい",
+      target: "おっしゃる",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Imperative
+    ),
+    Rule(
+      source: "きましょう",
+      target: "く",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.PoliteVolitional
+    ),
+    Rule(
+      source: "きましょう",
+      target: "くる",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.KuruVerb,
+      reason: DeinflectionReason.PoliteVolitional
+    ),
+    Rule(
+      source: "ぎましょう",
+      target: "ぐ",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.PoliteVolitional
+    ),
+    Rule(
+      source: "しましょう",
+      target: "す",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.PoliteVolitional
+    ),
+    Rule(
+      source: "しましょう",
+      target: "する",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.SuruVerb,
+      reason: DeinflectionReason.PoliteVolitional
+    ),
+    Rule(
+      source: "ちましょう",
+      target: "つ",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.PoliteVolitional
+    ),
+    Rule(
+      source: "にましょう",
+      target: "ぬ",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.PoliteVolitional
+    ),
+    Rule(
+      source: "のたもうた",
+      target: "のたまう",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Past
+    ),
+    Rule(
+      source: "のたもうて",
+      target: "のたまう",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Te
+    ),
+    Rule(
+      source: "びましょう",
+      target: "ぶ",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.PoliteVolitional
+    ),
+    Rule(
+      source: "みましょう",
+      target: "む",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.PoliteVolitional
+    ),
+    Rule(
+      source: "りましょう",
+      target: "る",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.PoliteVolitional
+    ),
+    Rule(
+      source: "いじゃう",
+      target: "ぐ",
+      sourceConjugationGroupValue: ConjugationGroup.GodanVerb,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Chau
+    ),
+    Rule(
+      source: "いすぎる",
+      target: "う",
+      sourceConjugationGroupValue: ConjugationGroup.IchidanVerb,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Sugiru
+    ),
+    Rule(
+      source: "いちゃう",
+      target: "く",
+      sourceConjugationGroupValue: ConjugationGroup.GodanVerb,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Chau
+    ),
+    Rule(
+      source: "いったら",
+      target: "いく",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Tara
+    ),
+    Rule(
+      source: "いったり",
+      target: "いく",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Tari
+    ),
+    Rule(
+      source: "いている",
+      target: "く",
+      sourceConjugationGroupValue: ConjugationGroup.IchidanVerb,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Continuous
+    ),
+    Rule(
+      source: "いでいる",
+      target: "ぐ",
+      sourceConjugationGroupValue: ConjugationGroup.IchidanVerb,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Continuous
+    ),
+    Rule(
+      source: "いなさい",
+      target: "う",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Nasai
+    ),
+    Rule(
+      source: "いました",
+      target: "う",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.PolitePast
+    ),
+    Rule(
+      source: "いません",
+      target: "う",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.PoliteNegative
+    ),
+    Rule(
+      source: "おうたら",
+      target: "おう",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Tara
+    ),
+    Rule(
+      source: "おうたり",
+      target: "おう",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Tari
+    ),
+    Rule(
+      source: "仰います",
+      target: "仰る",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Polite
+    ),
+    Rule(
+      source: "かされる",
+      target: "く",
+      sourceConjugationGroupValue: ConjugationGroup.IchidanVerb,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.CausativePassive
+    ),
+    Rule(
+      source: "かったら",
+      target: "い",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.IAdjective,
+      reason: DeinflectionReason.Tara
+    ),
+    Rule(
+      source: "かったり",
+      target: "い",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.IAdjective,
+      reason: DeinflectionReason.Tari
+    ),
+    Rule(
+      source: "がされる",
+      target: "ぐ",
+      sourceConjugationGroupValue: ConjugationGroup.IchidanVerb,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.CausativePassive
+    ),
+    Rule(
+      source: "きすぎる",
+      target: "く",
+      sourceConjugationGroupValue: ConjugationGroup.IchidanVerb,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Sugiru
+    ),
+    Rule(
+      source: "きすぎる",
+      target: "くる",
+      sourceConjugationGroupValue: ConjugationGroup.IchidanVerb,
+      targetConjugationGroupValue: ConjugationGroup.KuruVerb,
+      reason: DeinflectionReason.Sugiru
+    ),
+    Rule(
+      source: "ぎすぎる",
+      target: "ぐ",
+      sourceConjugationGroupValue: ConjugationGroup.IchidanVerb,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Sugiru
+    ),
+    Rule(
+      source: "きちゃう",
+      target: "くる",
+      sourceConjugationGroupValue: ConjugationGroup.GodanVerb,
+      targetConjugationGroupValue: ConjugationGroup.KuruVerb,
+      reason: DeinflectionReason.Chau
+    ),
+    Rule(
+      source: "きている",
+      target: "くる",
+      sourceConjugationGroupValue: ConjugationGroup.IchidanVerb,
+      targetConjugationGroupValue: ConjugationGroup.KuruVerb,
+      reason: DeinflectionReason.Continuous
+    ),
+    Rule(
+      source: "きなさい",
+      target: "く",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Nasai
+    ),
+    Rule(
+      source: "きなさい",
+      target: "くる",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.KuruVerb,
+      reason: DeinflectionReason.Nasai
+    ),
+    Rule(
+      source: "ぎなさい",
+      target: "ぐ",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Nasai
+    ),
+    Rule(
+      source: "きました",
+      target: "く",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.PolitePast
+    ),
+    Rule(
+      source: "きました",
+      target: "くる",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.KuruVerb,
+      reason: DeinflectionReason.PolitePast
+    ),
+    Rule(
+      source: "ぎました",
+      target: "ぐ",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.PolitePast
+    ),
+    Rule(
+      source: "きません",
+      target: "く",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.PoliteNegative
+    ),
+    Rule(
+      source: "きません",
+      target: "くる",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.KuruVerb,
+      reason: DeinflectionReason.PoliteNegative
+    ),
+    Rule(
+      source: "ぎません",
+      target: "ぐ",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.PoliteNegative
+    ),
+    Rule(
+      source: "こうたら",
+      target: "こう",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Tara
+    ),
+    Rule(
+      source: "こうたり",
+      target: "こう",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Tari
+    ),
+    Rule(
+      source: "こさせる",
+      target: "くる",
+      sourceConjugationGroupValue: ConjugationGroup.IchidanVerb,
+      targetConjugationGroupValue: ConjugationGroup.KuruVerb,
+      reason: DeinflectionReason.Causative
+    ),
+    Rule(
+      source: "こられる",
+      target: "くる",
+      sourceConjugationGroupValue: ConjugationGroup.IchidanVerb,
+      targetConjugationGroupValue: ConjugationGroup.KuruVerb,
+      reason: DeinflectionReason.PotentialOrPassive
+    ),
+    Rule(
+      source: "しすぎる",
+      target: "す",
+      sourceConjugationGroupValue: ConjugationGroup.IchidanVerb,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Sugiru
+    ),
+    Rule(
+      source: "しすぎる",
+      target: "する",
+      sourceConjugationGroupValue: ConjugationGroup.IchidanVerb,
+      targetConjugationGroupValue: ConjugationGroup.SuruVerb,
+      reason: DeinflectionReason.Sugiru
+    ),
+    Rule(
+      source: "しちゃう",
+      target: "す",
+      sourceConjugationGroupValue: ConjugationGroup.GodanVerb,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Chau
+    ),
+    Rule(
+      source: "しちゃう",
+      target: "する",
+      sourceConjugationGroupValue: ConjugationGroup.GodanVerb,
+      targetConjugationGroupValue: ConjugationGroup.SuruVerb,
+      reason: DeinflectionReason.Chau
+    ),
+    Rule(
+      source: "している",
+      target: "す",
+      sourceConjugationGroupValue: ConjugationGroup.IchidanVerb,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Continuous
+    ),
+    Rule(
+      source: "している",
+      target: "する",
+      sourceConjugationGroupValue: ConjugationGroup.IchidanVerb,
+      targetConjugationGroupValue: ConjugationGroup.SuruVerb,
+      reason: DeinflectionReason.Continuous
+    ),
+    Rule(
+      source: "しなさい",
+      target: "す",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Nasai
+    ),
+    Rule(
+      source: "しなさい",
+      target: "する",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.SuruVerb,
+      reason: DeinflectionReason.Nasai
+    ),
+    Rule(
+      source: "しました",
+      target: "す",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.PolitePast
+    ),
+    Rule(
+      source: "しました",
+      target: "する",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.SuruVerb,
+      reason: DeinflectionReason.PolitePast
+    ),
+    Rule(
+      source: "しません",
+      target: "す",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.PoliteNegative
+    ),
+    Rule(
+      source: "しません",
+      target: "する",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.SuruVerb,
+      reason: DeinflectionReason.PoliteNegative
+    ),
+    Rule(
+      source: "そうたら",
+      target: "そう",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Tara
+    ),
+    Rule(
+      source: "そうたり",
+      target: "そう",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Tari
+    ),
+    Rule(
+      source: "たされる",
+      target: "つ",
+      sourceConjugationGroupValue: ConjugationGroup.IchidanVerb,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.CausativePassive
+    ),
+    Rule(
+      source: "ちすぎる",
+      target: "つ",
+      sourceConjugationGroupValue: ConjugationGroup.IchidanVerb,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Sugiru
+    ),
+    Rule(
+      source: "ちなさい",
+      target: "つ",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Nasai
+    ),
+    Rule(
+      source: "ちました",
+      target: "つ",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.PolitePast
+    ),
+    Rule(
+      source: "ちません",
+      target: "つ",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.PoliteNegative
+    ),
+    Rule(
+      source: "っちゃう",
+      target: "う",
+      sourceConjugationGroupValue: ConjugationGroup.GodanVerb,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Chau
+    ),
+    Rule(
+      source: "っちゃう",
+      target: "く",
+      sourceConjugationGroupValue: ConjugationGroup.GodanVerb,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Chau
+    ),
+    Rule(
+      source: "っちゃう",
+      target: "つ",
+      sourceConjugationGroupValue: ConjugationGroup.GodanVerb,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Chau
+    ),
+    Rule(
+      source: "っちゃう",
+      target: "る",
+      sourceConjugationGroupValue: ConjugationGroup.GodanVerb,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Chau
+    ),
+    Rule(
+      source: "っている",
+      target: "う",
+      sourceConjugationGroupValue: ConjugationGroup.IchidanVerb,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Continuous
+    ),
+    Rule(
+      source: "っている",
+      target: "つ",
+      sourceConjugationGroupValue: ConjugationGroup.IchidanVerb,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Continuous
+    ),
+    Rule(
+      source: "っている",
+      target: "る",
+      sourceConjugationGroupValue: ConjugationGroup.IchidanVerb,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Continuous
+    ),
+    Rule(
+      source: "とうたら",
+      target: "とう",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Tara
+    ),
+    Rule(
+      source: "とうたり",
+      target: "とう",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Tari
+    ),
+    Rule(
+      source: "なされる",
+      target: "ぬ",
+      sourceConjugationGroupValue: ConjugationGroup.IchidanVerb,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.CausativePassive
+    ),
+    Rule(
+      source: "にすぎる",
+      target: "ぬ",
+      sourceConjugationGroupValue: ConjugationGroup.IchidanVerb,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Sugiru
+    ),
+    Rule(
+      source: "になさい",
+      target: "ぬ",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Nasai
+    ),
+    Rule(
+      source: "にました",
+      target: "ぬ",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.PolitePast
+    ),
+    Rule(
+      source: "にません",
+      target: "ぬ",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.PoliteNegative
+    ),
+    Rule(
+      source: "ばされる",
+      target: "ぶ",
+      sourceConjugationGroupValue: ConjugationGroup.IchidanVerb,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.CausativePassive
+    ),
+    Rule(
+      source: "びすぎる",
+      target: "ぶ",
+      sourceConjugationGroupValue: ConjugationGroup.IchidanVerb,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Sugiru
+    ),
+    Rule(
+      source: "びなさい",
+      target: "ぶ",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Nasai
+    ),
+    Rule(
+      source: "びました",
+      target: "ぶ",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.PolitePast
+    ),
+    Rule(
+      source: "びません",
+      target: "ぶ",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.PoliteNegative
+    ),
+    Rule(
+      source: "まされる",
+      target: "む",
+      sourceConjugationGroupValue: ConjugationGroup.IchidanVerb,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.CausativePassive
+    ),
+    Rule(
+      source: "ましょう",
+      target: "る",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.IchidanVerb | ConjugationGroup.KuruVerb,
+      reason: DeinflectionReason.PoliteVolitional
+    ),
+    Rule(
+      source: "みすぎる",
+      target: "む",
+      sourceConjugationGroupValue: ConjugationGroup.IchidanVerb,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Sugiru
+    ),
+    Rule(
+      source: "みなさい",
+      target: "む",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Nasai
+    ),
+    Rule(
+      source: "みました",
+      target: "む",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.PolitePast
+    ),
+    Rule(
+      source: "みません",
+      target: "む",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.PoliteNegative
+    ),
+    Rule(
+      source: "らされる",
+      target: "る",
+      sourceConjugationGroupValue: ConjugationGroup.IchidanVerb,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.CausativePassive
+    ),
+    Rule(
+      source: "りすぎる",
+      target: "る",
+      sourceConjugationGroupValue: ConjugationGroup.IchidanVerb,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Sugiru
+    ),
+    Rule(
+      source: "りなさい",
+      target: "る",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Nasai
+    ),
+    Rule(
+      source: "りました",
+      target: "る",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.PolitePast
+    ),
+    Rule(
+      source: "りません",
+      target: "る",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.PoliteNegative
+    ),
+    Rule(
+      source: "わされる",
+      target: "う",
+      sourceConjugationGroupValue: ConjugationGroup.IchidanVerb,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.CausativePassive
+    ),
+    Rule(
+      source: "んじゃう",
+      target: "ぬ",
+      sourceConjugationGroupValue: ConjugationGroup.GodanVerb,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Chau
+    ),
+    Rule(
+      source: "んじゃう",
+      target: "ぶ",
+      sourceConjugationGroupValue: ConjugationGroup.GodanVerb,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Chau
+    ),
+    Rule(
+      source: "んじゃう",
+      target: "む",
+      sourceConjugationGroupValue: ConjugationGroup.GodanVerb,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Chau
+    ),
+    Rule(
+      source: "んでいる",
+      target: "ぬ",
+      sourceConjugationGroupValue: ConjugationGroup.IchidanVerb,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Continuous
+    ),
+    Rule(
+      source: "んでいる",
+      target: "ぶ",
+      sourceConjugationGroupValue: ConjugationGroup.IchidanVerb,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Continuous
+    ),
+    Rule(
+      source: "んでいる",
+      target: "む",
+      sourceConjugationGroupValue: ConjugationGroup.IchidanVerb,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Continuous
+    ),
+    Rule(
+      source: "行ったら",
+      target: "行く",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Tara
+    ),
+    Rule(
+      source: "行ったり",
+      target: "行く",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Tari
+    ),
+    Rule(
+      source: "逝ったら",
+      target: "逝く",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Tara
+    ),
+    Rule(
+      source: "逝ったり",
+      target: "逝く",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Tari
+    ),
+    Rule(
+      source: "往ったら",
+      target: "往く",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Tara
+    ),
+    Rule(
+      source: "往ったり",
+      target: "往く",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Tari
+    ),
+    Rule(
+      source: "逝ったら",
+      target: "逝く",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Tara
+    ),
+    Rule(
+      source: "逝ったり",
+      target: "逝く",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Tari
+    ),
+    Rule(
+      source: "往ったら",
+      target: "往く",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Tara
+    ),
+    Rule(
+      source: "往ったり",
+      target: "往く",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Tari
+    ),
+    Rule(
+      source: "請うたら",
+      target: "請う",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Tara
+    ),
+    Rule(
+      source: "請うたり",
+      target: "請う",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Tari
+    ),
+    Rule(
+      source: "乞うたら",
+      target: "乞う",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Tara
+    ),
+    Rule(
+      source: "乞うたり",
+      target: "乞う",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Tari
+    ),
+    Rule(
+      source: "恋うたら",
+      target: "恋う",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Tara
+    ),
+    Rule(
+      source: "恋うたり",
+      target: "恋う",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Tari
+    ),
+    Rule(
+      source: "来させる",
+      target: "来る",
+      sourceConjugationGroupValue: ConjugationGroup.IchidanVerb,
+      targetConjugationGroupValue: ConjugationGroup.KuruVerb,
+      reason: DeinflectionReason.Causative
+    ),
+    Rule(
+      source: "來させる",
+      target: "來る",
+      sourceConjugationGroupValue: ConjugationGroup.IchidanVerb,
+      targetConjugationGroupValue: ConjugationGroup.KuruVerb,
+      reason: DeinflectionReason.Causative
+    ),
+    Rule(
+      source: "来ました",
+      target: "来る",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.KuruVerb,
+      reason: DeinflectionReason.PolitePast
+    ),
+    Rule(
+      source: "来ません",
+      target: "来る",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.KuruVerb,
+      reason: DeinflectionReason.PoliteNegative
+    ),
+    Rule(
+      source: "來ました",
+      target: "來る",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.KuruVerb,
+      reason: DeinflectionReason.PolitePast
+    ),
+    Rule(
+      source: "來ません",
+      target: "來る",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.KuruVerb,
+      reason: DeinflectionReason.PoliteNegative
+    ),
+    Rule(
+      source: "来られる",
+      target: "来る",
+      sourceConjugationGroupValue: ConjugationGroup.IchidanVerb,
+      targetConjugationGroupValue: ConjugationGroup.KuruVerb,
+      reason: DeinflectionReason.PotentialOrPassive
+    ),
+    Rule(
+      source: "來られる",
+      target: "來る",
+      sourceConjugationGroupValue: ConjugationGroup.IchidanVerb,
+      targetConjugationGroupValue: ConjugationGroup.KuruVerb,
+      reason: DeinflectionReason.PotentialOrPassive
+    ),
+    Rule(
+      source: "問うたら",
+      target: "問う",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Tara
+    ),
+    Rule(
+      source: "問うたり",
+      target: "問う",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Tari
+    ),
+    Rule(
+      source: "負うたら",
+      target: "負う",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Tara
+    ),
+    Rule(
+      source: "負うたり",
+      target: "負う",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Tari
+    ),
+    Rule(
+      source: "沿うたら",
+      target: "沿う",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Tara
+    ),
+    Rule(
+      source: "沿うたり",
+      target: "沿う",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Tari
+    ),
+    Rule(
+      source: "添うたら",
+      target: "添う",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Tara
+    ),
+    Rule(
+      source: "添うたり",
+      target: "添う",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Tari
+    ),
+    Rule(
+      source: "副うたら",
+      target: "副う",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Tara
+    ),
+    Rule(
+      source: "副うたり",
+      target: "副う",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Tari
+    ),
+    Rule(
+      source: "厭うたら",
+      target: "厭う",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Tara
+    ),
+    Rule(
+      source: "厭うたり",
+      target: "厭う",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Tari
+    ),
+    Rule(
+      source: "いそう",
+      target: "う",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Sou
+    ),
+    Rule(
+      source: "いたい",
+      target: "う",
+      sourceConjugationGroupValue: ConjugationGroup.IAdjective,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Tai
+    ),
+    Rule(
+      source: "いたら",
+      target: "く",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Tara
+    ),
+    Rule(
+      source: "いだら",
+      target: "ぐ",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Tara
+    ),
+    Rule(
+      source: "いたり",
+      target: "く",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Tari
+    ),
+    Rule(
+      source: "いだり",
+      target: "ぐ",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Tari
+    ),
+    Rule(
+      source: "いった",
+      target: "いく",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Past
+    ),
+    Rule(
+      source: "いって",
+      target: "いく",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Te
+    ),
+    Rule(
+      source: "いてる",
+      target: "く",
+      sourceConjugationGroupValue: ConjugationGroup.IchidanVerb,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Continuous
+    ),
+    Rule(
+      source: "いでる",
+      target: "ぐ",
+      sourceConjugationGroupValue: ConjugationGroup.IchidanVerb,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Continuous
+    ),
+    Rule(
+      source: "いとく",
+      target: "く",
+      sourceConjugationGroupValue: ConjugationGroup.GodanVerb,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Toku
+    ),
+    Rule(
+      source: "いどく",
+      target: "ぐ",
+      sourceConjugationGroupValue: ConjugationGroup.GodanVerb,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Toku
+    ),
+    Rule(
+      source: "います",
+      target: "う",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Polite
+    ),
+    Rule(
+      source: "おうた",
+      target: "おう",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Past
+    ),
+    Rule(
+      source: "おうて",
+      target: "おう",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Te
+    ),
+    Rule(
+      source: "かせる",
+      target: "く",
+      sourceConjugationGroupValue: ConjugationGroup.IchidanVerb,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Causative
+    ),
+    Rule(
+      source: "がせる",
+      target: "ぐ",
+      sourceConjugationGroupValue: ConjugationGroup.IchidanVerb,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Causative
+    ),
+    Rule(
+      source: "かった",
+      target: "い",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.IAdjective,
+      reason: DeinflectionReason.Past
+    ),
+    Rule(
+      source: "かない",
+      target: "く",
+      sourceConjugationGroupValue: ConjugationGroup.IAdjective,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Negative
+    ),
+    Rule(
+      source: "がない",
+      target: "ぐ",
+      sourceConjugationGroupValue: ConjugationGroup.IAdjective,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Negative
+    ),
+    Rule(
+      source: "かれる",
+      target: "く",
+      sourceConjugationGroupValue: ConjugationGroup.IchidanVerb,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Passive
+    ),
+    Rule(
+      source: "がれる",
+      target: "ぐ",
+      sourceConjugationGroupValue: ConjugationGroup.IchidanVerb,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Passive
+    ),
+    Rule(
+      source: "きそう",
+      target: "く",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Sou
+    ),
+    Rule(
+      source: "きそう",
+      target: "くる",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.KuruVerb,
+      reason: DeinflectionReason.Sou
+    ),
+    Rule(
+      source: "ぎそう",
+      target: "ぐ",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Sou
+    ),
+    Rule(
+      source: "きたい",
+      target: "く",
+      sourceConjugationGroupValue: ConjugationGroup.IAdjective,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Tai
+    ),
+    Rule(
+      source: "きたい",
+      target: "くる",
+      sourceConjugationGroupValue: ConjugationGroup.IAdjective,
+      targetConjugationGroupValue: ConjugationGroup.KuruVerb,
+      reason: DeinflectionReason.Tai
+    ),
+    Rule(
+      source: "ぎたい",
+      target: "ぐ",
+      sourceConjugationGroupValue: ConjugationGroup.IAdjective,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Tai
+    ),
+    Rule(
+      source: "きたら",
+      target: "くる",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.KuruVerb,
+      reason: DeinflectionReason.Tara
+    ),
+    Rule(
+      source: "きたり",
+      target: "くる",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.KuruVerb,
+      reason: DeinflectionReason.Tari
+    ),
+    Rule(
+      source: "きてる",
+      target: "くる",
+      sourceConjugationGroupValue: ConjugationGroup.IchidanVerb,
+      targetConjugationGroupValue: ConjugationGroup.KuruVerb,
+      reason: DeinflectionReason.Continuous
+    ),
+    Rule(
+      source: "きとく",
+      target: "くる",
+      sourceConjugationGroupValue: ConjugationGroup.GodanVerb,
+      targetConjugationGroupValue: ConjugationGroup.KuruVerb,
+      reason: DeinflectionReason.Toku
+    ),
+    Rule(
+      source: "きます",
+      target: "く",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Polite
+    ),
+    Rule(
+      source: "きます",
+      target: "くる",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.KuruVerb,
+      reason: DeinflectionReason.Polite
+    ),
+    Rule(
+      source: "ぎます",
+      target: "ぐ",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Polite
+    ),
+    Rule(
+      source: "くない",
+      target: "い",
+      sourceConjugationGroupValue: ConjugationGroup.IAdjective,
+      targetConjugationGroupValue: ConjugationGroup.IAdjective,
+      reason: DeinflectionReason.Negative
+    ),
+    Rule(
+      source: "ければ",
+      target: "い",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.IAdjective,
+      reason: DeinflectionReason.Ba
+    ),
+    Rule(
+      source: "こうた",
+      target: "こう",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Past
+    ),
+    Rule(
+      source: "こうて",
+      target: "こう",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Te
+    ),
+    Rule(
+      source: "こない",
+      target: "くる",
+      sourceConjugationGroupValue: ConjugationGroup.IAdjective,
+      targetConjugationGroupValue: ConjugationGroup.KuruVerb,
+      reason: DeinflectionReason.Negative
+    ),
+    Rule(
+      source: "こよう",
+      target: "くる",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.KuruVerb,
+      reason: DeinflectionReason.Volitional
+    ),
+    Rule(
+      source: "これる",
+      target: "くる",
+      sourceConjugationGroupValue: ConjugationGroup.IchidanVerb,
+      targetConjugationGroupValue: ConjugationGroup.KuruVerb,
+      reason: DeinflectionReason.Potential
+    ),
+    Rule(
+      source: "来れる",
+      target: "来る",
+      sourceConjugationGroupValue: ConjugationGroup.IchidanVerb,
+      targetConjugationGroupValue: ConjugationGroup.KuruVerb,
+      reason: DeinflectionReason.Potential
+    ),
+    Rule(
+      source: "來れる",
+      target: "來る",
+      sourceConjugationGroupValue: ConjugationGroup.IchidanVerb,
+      targetConjugationGroupValue: ConjugationGroup.KuruVerb,
+      reason: DeinflectionReason.Potential
+    ),
+    Rule(
+      source: "させる",
+      target: "する",
+      sourceConjugationGroupValue: ConjugationGroup.IchidanVerb,
+      targetConjugationGroupValue: ConjugationGroup.SuruVerb,
+      reason: DeinflectionReason.Causative
+    ),
+    Rule(
+      source: "させる",
+      target: "る",
+      sourceConjugationGroupValue: ConjugationGroup.IchidanVerb,
+      targetConjugationGroupValue: ConjugationGroup.IchidanVerb,
+      reason: DeinflectionReason.Causative
+    ),
+    Rule(
+      source: "させる",
+      target: "す",
+      sourceConjugationGroupValue: ConjugationGroup.IchidanVerb,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Causative
+    ),
+    Rule(
+      source: "さない",
+      target: "す",
+      sourceConjugationGroupValue: ConjugationGroup.IAdjective,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Negative
+    ),
+    Rule(
+      source: "される",
+      target: "す",
+      sourceConjugationGroupValue: ConjugationGroup.IchidanVerb,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Passive
+    ),
+    Rule(
+      source: "される",
+      target: "する",
+      sourceConjugationGroupValue: ConjugationGroup.IchidanVerb,
+      targetConjugationGroupValue: ConjugationGroup.SuruVerb,
+      reason: DeinflectionReason.Passive
+    ),
+    Rule(
+      source: "しそう",
+      target: "す",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Sou
+    ),
+    Rule(
+      source: "しそう",
+      target: "する",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.SuruVerb,
+      reason: DeinflectionReason.Sou
+    ),
+    Rule(
+      source: "したい",
+      target: "す",
+      sourceConjugationGroupValue: ConjugationGroup.IAdjective,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Tai
+    ),
+    Rule(
+      source: "したい",
+      target: "する",
+      sourceConjugationGroupValue: ConjugationGroup.IAdjective,
+      targetConjugationGroupValue: ConjugationGroup.SuruVerb,
+      reason: DeinflectionReason.Tai
+    ),
+    Rule(
+      source: "したら",
+      target: "す",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Tara
+    ),
+    Rule(
+      source: "したら",
+      target: "する",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.SuruVerb,
+      reason: DeinflectionReason.Tara
+    ),
+    Rule(
+      source: "したり",
+      target: "す",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Tari
+    ),
+    Rule(
+      source: "したり",
+      target: "する",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.SuruVerb,
+      reason: DeinflectionReason.Tari
+    ),
+    Rule(
+      source: "してる",
+      target: "す",
+      sourceConjugationGroupValue: ConjugationGroup.IchidanVerb,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Continuous
+    ),
+    Rule(
+      source: "してる",
+      target: "する",
+      sourceConjugationGroupValue: ConjugationGroup.IchidanVerb,
+      targetConjugationGroupValue: ConjugationGroup.SuruVerb,
+      reason: DeinflectionReason.Continuous
+    ),
+    Rule(
+      source: "しとく",
+      target: "す",
+      sourceConjugationGroupValue: ConjugationGroup.GodanVerb,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Toku
+    ),
+    Rule(
+      source: "しとく",
+      target: "する",
+      sourceConjugationGroupValue: ConjugationGroup.GodanVerb,
+      targetConjugationGroupValue: ConjugationGroup.SuruVerb,
+      reason: DeinflectionReason.Toku
+    ),
+    Rule(
+      source: "しない",
+      target: "する",
+      sourceConjugationGroupValue: ConjugationGroup.IAdjective,
+      targetConjugationGroupValue: ConjugationGroup.SuruVerb,
+      reason: DeinflectionReason.Negative
+    ),
+    Rule(
+      source: "します",
+      target: "す",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Polite
+    ),
+    Rule(
+      source: "します",
+      target: "する",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.SuruVerb,
+      reason: DeinflectionReason.Polite
+    ),
+    Rule(
+      source: "しよう",
+      target: "する",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.SuruVerb,
+      reason: DeinflectionReason.Volitional
+    ),
+    Rule(
+      source: "すぎる",
+      target: "い",
+      sourceConjugationGroupValue: ConjugationGroup.IchidanVerb,
+      targetConjugationGroupValue: ConjugationGroup.IAdjective,
+      reason: DeinflectionReason.Sugiru
+    ),
+    Rule(
+      source: "すぎる",
+      target: "る",
+      sourceConjugationGroupValue: ConjugationGroup.IchidanVerb,
+      targetConjugationGroupValue: ConjugationGroup.IchidanVerb | ConjugationGroup.KuruVerb,
+      reason: DeinflectionReason.Sugiru
+    ),
+    Rule(
+      source: "そうた",
+      target: "そう",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Past
+    ),
+    Rule(
+      source: "そうて",
+      target: "そう",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Te
+    ),
+    Rule(
+      source: "たせる",
+      target: "つ",
+      sourceConjugationGroupValue: ConjugationGroup.IchidanVerb,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Causative
+    ),
+    Rule(
+      source: "たない",
+      target: "つ",
+      sourceConjugationGroupValue: ConjugationGroup.IAdjective,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Negative
+    ),
+    Rule(
+      source: "たれる",
+      target: "つ",
+      sourceConjugationGroupValue: ConjugationGroup.IchidanVerb,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Passive
+    ),
+    Rule(
+      source: "ちそう",
+      target: "つ",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Sou
+    ),
+    Rule(
+      source: "ちたい",
+      target: "つ",
+      sourceConjugationGroupValue: ConjugationGroup.IAdjective,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Tai
+    ),
+    Rule(
+      source: "ちます",
+      target: "つ",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Polite
+    ),
+    Rule(
+      source: "ちゃう",
+      target: "る",
+      sourceConjugationGroupValue: ConjugationGroup.GodanVerb,
+      targetConjugationGroupValue: ConjugationGroup.IchidanVerb | ConjugationGroup.KuruVerb,
+      reason: DeinflectionReason.Chau
+    ),
+    Rule(
+      source: "ったら",
+      target: "う",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Tara
+    ),
+    Rule(
+      source: "ったら",
+      target: "つ",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Tara
+    ),
+    Rule(
+      source: "ったら",
+      target: "る",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Tara
+    ),
+    Rule(
+      source: "ったり",
+      target: "う",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Tari
+    ),
+    Rule(
+      source: "ったり",
+      target: "つ",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Tari
+    ),
+    Rule(
+      source: "ったり",
+      target: "る",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Tari
+    ),
+    Rule(
+      source: "ってる",
+      target: "う",
+      sourceConjugationGroupValue: ConjugationGroup.IchidanVerb,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Continuous
+    ),
+    Rule(
+      source: "ってる",
+      target: "つ",
+      sourceConjugationGroupValue: ConjugationGroup.IchidanVerb,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Continuous
+    ),
+    Rule(
+      source: "ってる",
+      target: "る",
+      sourceConjugationGroupValue: ConjugationGroup.IchidanVerb,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Continuous
+    ),
+    Rule(
+      source: "っとく",
+      target: "う",
+      sourceConjugationGroupValue: ConjugationGroup.GodanVerb,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Toku
+    ),
+    Rule(
+      source: "っとく",
+      target: "つ",
+      sourceConjugationGroupValue: ConjugationGroup.GodanVerb,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Toku
+    ),
+    Rule(
+      source: "っとく",
+      target: "る",
+      sourceConjugationGroupValue: ConjugationGroup.GodanVerb,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Toku
+    ),
+    Rule(
+      source: "ている",
+      target: "る",
+      sourceConjugationGroupValue: ConjugationGroup.IchidanVerb,
+      targetConjugationGroupValue: ConjugationGroup.IchidanVerb | ConjugationGroup.KuruVerb,
+      reason: DeinflectionReason.Continuous
+    ),
+    Rule(
+      source: "とうた",
+      target: "とう",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Past
+    ),
+    Rule(
+      source: "とうて",
+      target: "とう",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Te
+    ),
+    Rule(
+      source: "なさい",
+      target: "る",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.IchidanVerb | ConjugationGroup.KuruVerb,
+      reason: DeinflectionReason.Nasai
+    ),
+    Rule(
+      source: "なせる",
+      target: "ぬ",
+      sourceConjugationGroupValue: ConjugationGroup.IchidanVerb,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Causative
+    ),
+    Rule(
+      source: "なない",
+      target: "ぬ",
+      sourceConjugationGroupValue: ConjugationGroup.IAdjective,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Negative
+    ),
+    Rule(
+      source: "なれる",
+      target: "ぬ",
+      sourceConjugationGroupValue: ConjugationGroup.IchidanVerb,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Passive
+    ),
+    Rule(
+      source: "にそう",
+      target: "ぬ",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Sou
+    ),
+    Rule(
+      source: "にたい",
+      target: "ぬ",
+      sourceConjugationGroupValue: ConjugationGroup.IAdjective,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Tai
+    ),
+    Rule(
+      source: "にます",
+      target: "ぬ",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Polite
+    ),
+    Rule(
+      source: "ばせる",
+      target: "ぶ",
+      sourceConjugationGroupValue: ConjugationGroup.IchidanVerb,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Causative
+    ),
+    Rule(
+      source: "ばない",
+      target: "ぶ",
+      sourceConjugationGroupValue: ConjugationGroup.IAdjective,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Negative
+    ),
+    Rule(
+      source: "ばれる",
+      target: "ぶ",
+      sourceConjugationGroupValue: ConjugationGroup.IchidanVerb,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Passive
+    ),
+    Rule(
+      source: "びそう",
+      target: "ぶ",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Sou
+    ),
+    Rule(
+      source: "びたい",
+      target: "ぶ",
+      sourceConjugationGroupValue: ConjugationGroup.IAdjective,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Tai
+    ),
+    Rule(
+      source: "びます",
+      target: "ぶ",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Polite
+    ),
+    Rule(
+      source: "ました",
+      target: "る",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.IchidanVerb,
+      reason: DeinflectionReason.PolitePast
+    ),
+    Rule(
+      source: "ませる",
+      target: "む",
+      sourceConjugationGroupValue: ConjugationGroup.IchidanVerb,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Causative
+    ),
+    Rule(
+      source: "ません",
+      target: "る",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.IchidanVerb,
+      reason: DeinflectionReason.PoliteNegative
+    ),
+    Rule(
+      source: "まない",
+      target: "む",
+      sourceConjugationGroupValue: ConjugationGroup.IAdjective,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Negative
+    ),
+    Rule(
+      source: "まれる",
+      target: "む",
+      sourceConjugationGroupValue: ConjugationGroup.IchidanVerb,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Passive
+    ),
+    Rule(
+      source: "みそう",
+      target: "む",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Sou
+    ),
+    Rule(
+      source: "みたい",
+      target: "む",
+      sourceConjugationGroupValue: ConjugationGroup.IAdjective,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Tai
+    ),
+    Rule(
+      source: "みます",
+      target: "む",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Polite
+    ),
+    Rule(
+      source: "らせる",
+      target: "る",
+      sourceConjugationGroupValue: ConjugationGroup.IchidanVerb,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Causative
+    ),
+    Rule(
+      source: "らない",
+      target: "る",
+      sourceConjugationGroupValue: ConjugationGroup.IAdjective,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Negative
+    ),
+    Rule(
+      source: "られる",
+      target: "る",
+      sourceConjugationGroupValue: ConjugationGroup.IchidanVerb,
+      targetConjugationGroupValue: ConjugationGroup.IchidanVerb | ConjugationGroup.KuruVerb,
+      reason: DeinflectionReason.PotentialOrPassive
+    ),
+    Rule(
+      source: "られる",
+      target: "る",
+      sourceConjugationGroupValue: ConjugationGroup.IchidanVerb,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Passive
+    ),
+    Rule(
+      source: "りそう",
+      target: "る",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Sou
+    ),
+    Rule(
+      source: "りたい",
+      target: "る",
+      sourceConjugationGroupValue: ConjugationGroup.IAdjective,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Tai
+    ),
+    Rule(
+      source: "ります",
+      target: "る",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Polite
+    ),
+    Rule(
+      source: "わせる",
+      target: "う",
+      sourceConjugationGroupValue: ConjugationGroup.IchidanVerb,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Causative
+    ),
+    Rule(
+      source: "わない",
+      target: "う",
+      sourceConjugationGroupValue: ConjugationGroup.IAdjective,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Negative
+    ),
+    Rule(
+      source: "われる",
+      target: "う",
+      sourceConjugationGroupValue: ConjugationGroup.IchidanVerb,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Passive
+    ),
+    Rule(
+      source: "んだら",
+      target: "ぬ",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Tara
+    ),
+    Rule(
+      source: "んだら",
+      target: "ぶ",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Tara
+    ),
+    Rule(
+      source: "んだら",
+      target: "む",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Tara
+    ),
+    Rule(
+      source: "んだり",
+      target: "ぬ",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Tari
+    ),
+    Rule(
+      source: "んだり",
+      target: "ぶ",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Tari
+    ),
+    Rule(
+      source: "んだり",
+      target: "む",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Tari
+    ),
+    Rule(
+      source: "んでる",
+      target: "ぬ",
+      sourceConjugationGroupValue: ConjugationGroup.IchidanVerb,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Continuous
+    ),
+    Rule(
+      source: "んでる",
+      target: "ぶ",
+      sourceConjugationGroupValue: ConjugationGroup.IchidanVerb,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Continuous
+    ),
+    Rule(
+      source: "んでる",
+      target: "む",
+      sourceConjugationGroupValue: ConjugationGroup.IchidanVerb,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Continuous
+    ),
+    Rule(
+      source: "んどく",
+      target: "ぬ",
+      sourceConjugationGroupValue: ConjugationGroup.GodanVerb,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Toku
+    ),
+    Rule(
+      source: "んどく",
+      target: "ぶ",
+      sourceConjugationGroupValue: ConjugationGroup.GodanVerb,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Toku
+    ),
+    Rule(
+      source: "んどく",
+      target: "む",
+      sourceConjugationGroupValue: ConjugationGroup.GodanVerb,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Toku
+    ),
+    Rule(
+      source: "行った",
+      target: "行く",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Past
+    ),
+    Rule(
+      source: "行って",
+      target: "行く",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Te
+    ),
+    Rule(
+      source: "逝った",
+      target: "逝く",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Past
+    ),
+    Rule(
+      source: "逝って",
+      target: "逝く",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Te
+    ),
+    Rule(
+      source: "往った",
+      target: "往く",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Past
+    ),
+    Rule(
+      source: "往って",
+      target: "往く",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Te
+    ),
+    Rule(
+      source: "請うた",
+      target: "請う",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Past
+    ),
+    Rule(
+      source: "請うて",
+      target: "請う",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Te
+    ),
+    Rule(
+      source: "乞うた",
+      target: "乞う",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Past
+    ),
+    Rule(
+      source: "乞うて",
+      target: "乞う",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Te
+    ),
+    Rule(
+      source: "恋うた",
+      target: "恋う",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Past
+    ),
+    Rule(
+      source: "恋うて",
+      target: "恋う",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Te
+    ),
+    Rule(
+      source: "問うた",
+      target: "問う",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Past
+    ),
+    Rule(
+      source: "問うて",
+      target: "問う",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Te
+    ),
+    Rule(
+      source: "負うた",
+      target: "負う",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Past
+    ),
+    Rule(
+      source: "負うて",
+      target: "負う",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Te
+    ),
+    Rule(
+      source: "沿うた",
+      target: "沿う",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Past
+    ),
+    Rule(
+      source: "沿うて",
+      target: "沿う",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Te
+    ),
+    Rule(
+      source: "添うた",
+      target: "添う",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Past
+    ),
+    Rule(
+      source: "添うて",
+      target: "添う",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Te
+    ),
+    Rule(
+      source: "副うた",
+      target: "副う",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Past
+    ),
+    Rule(
+      source: "副うて",
+      target: "副う",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Te
+    ),
+    Rule(
+      source: "厭うた",
+      target: "厭う",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Past
+    ),
+    Rule(
+      source: "厭うて",
+      target: "厭う",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Te
+    ),
+    Rule(
+      source: "いた",
+      target: "く",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Past
+    ),
+    Rule(
+      source: "いだ",
+      target: "ぐ",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Past
+    ),
+    Rule(
+      source: "いて",
+      target: "く",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Te
+    ),
+    Rule(
+      source: "いで",
+      target: "ぐ",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Te
+    ),
+    Rule(
+      source: "えば",
+      target: "う",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Ba
+    ),
+    Rule(
+      source: "える",
+      target: "う",
+      sourceConjugationGroupValue: ConjugationGroup.IchidanVerb,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Potential
+    ),
+    Rule(
+      source: "おう",
+      target: "う",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Volitional
+    ),
+    Rule(
+      source: "仰い",
+      target: "仰る",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.MasuStem
+    ),
+    Rule(
+      source: "仰い",
+      target: "仰る",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Imperative
+    ),
+    Rule(
+      source: "かず",
+      target: "く",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Zu
+    ),
+    Rule(
+      source: "がず",
+      target: "ぐ",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Zu
+    ),
+    Rule(
+      source: "かぬ",
+      target: "く",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Negative
+    ),
+    Rule(
+      source: "かん",
+      target: "く",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Negative
+    ),
+    Rule(
+      source: "がぬ",
+      target: "ぐ",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Negative
+    ),
+    Rule(
+      source: "がん",
+      target: "ぐ",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Negative
+    ),
+    Rule(
+      source: "きた",
+      target: "くる",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.KuruVerb,
+      reason: DeinflectionReason.Past
+    ),
+    Rule(
+      source: "きて",
+      target: "くる",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.KuruVerb,
+      reason: DeinflectionReason.Te
+    ),
+    Rule(
+      source: "くて",
+      target: "い",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.IAdjective,
+      reason: DeinflectionReason.Te
+    ),
+    Rule(
+      source: "けば",
+      target: "く",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Ba
+    ),
+    Rule(
+      source: "げば",
+      target: "ぐ",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Ba
+    ),
+    Rule(
+      source: "ける",
+      target: "く",
+      sourceConjugationGroupValue: ConjugationGroup.IchidanVerb,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Potential
+    ),
+    Rule(
+      source: "げる",
+      target: "ぐ",
+      sourceConjugationGroupValue: ConjugationGroup.IchidanVerb,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Potential
+    ),
+    Rule(
+      source: "こい",
+      target: "くる",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.KuruVerb,
+      reason: DeinflectionReason.Imperative
+    ),
+    Rule(
+      source: "こう",
+      target: "く",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Volitional
+    ),
+    Rule(
+      source: "ごう",
+      target: "ぐ",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Volitional
+    ),
+    Rule(
+      source: "こず",
+      target: "くる",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.KuruVerb,
+      reason: DeinflectionReason.Zu
+    ),
+    Rule(
+      source: "こぬ",
+      target: "くる",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.KuruVerb,
+      reason: DeinflectionReason.Negative
+    ),
+    Rule(
+      source: "こん",
+      target: "くる",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.KuruVerb,
+      reason: DeinflectionReason.Negative
+    ),
+    Rule(
+      source: "さず",
+      target: "す",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Zu
+    ),
+    Rule(
+      source: "さぬ",
+      target: "す",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Negative
+    ),
+    Rule(
+      source: "さん",
+      target: "す",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Negative
+    ),
+    Rule(
+      source: "した",
+      target: "す",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Past
+    ),
+    Rule(
+      source: "した",
+      target: "する",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.SuruVerb,
+      reason: DeinflectionReason.Past
+    ),
+    Rule(
+      source: "して",
+      target: "す",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Te
+    ),
+    Rule(
+      source: "して",
+      target: "する",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.SuruVerb,
+      reason: DeinflectionReason.Te
+    ),
+    Rule(
+      source: "しろ",
+      target: "する",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.SuruVerb,
+      reason: DeinflectionReason.Imperative
+    ),
+    Rule(
+      source: "せず",
+      target: "する",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.SuruVerb,
+      reason: DeinflectionReason.Zu
+    ),
+    Rule(
+      source: "せぬ",
+      target: "する",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.SuruVerb,
+      reason: DeinflectionReason.Negative
+    ),
+    Rule(
+      source: "せん",
+      target: "する",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.SuruVerb,
+      reason: DeinflectionReason.Negative
+    ),
+    Rule(
+      source: "せば",
+      target: "す",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Ba
+    ),
+    Rule(
+      source: "せよ",
+      target: "する",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.SuruVerb,
+      reason: DeinflectionReason.Imperative
+    ),
+    Rule(
+      source: "せる",
+      target: "す",
+      sourceConjugationGroupValue: ConjugationGroup.IchidanVerb,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Potential
+    ),
+    Rule(
+      source: "そう",
+      target: "い",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.IAdjective,
+      reason: DeinflectionReason.Sou
+    ),
+    Rule(
+      source: "そう",
+      target: "す",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Volitional
+    ),
+    Rule(
+      source: "そう",
+      target: "る",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.IchidanVerb | ConjugationGroup.KuruVerb,
+      reason: DeinflectionReason.Sou
+    ),
+    Rule(
+      source: "たい",
+      target: "る",
+      sourceConjugationGroupValue: ConjugationGroup.IAdjective,
+      targetConjugationGroupValue: ConjugationGroup.IchidanVerb | ConjugationGroup.KuruVerb,
+      reason: DeinflectionReason.Tai
+    ),
+    Rule(
+      source: "たず",
+      target: "つ",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Zu
+    ),
+    Rule(
+      source: "たぬ",
+      target: "つ",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Negative
+    ),
+    Rule(
+      source: "たん",
+      target: "つ",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Negative
+    ),
+    Rule(
+      source: "たら",
+      target: "る",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.IchidanVerb | ConjugationGroup.KuruVerb,
+      reason: DeinflectionReason.Tara
+    ),
+    Rule(
+      source: "たり",
+      target: "る",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.IchidanVerb | ConjugationGroup.KuruVerb,
+      reason: DeinflectionReason.Tari
+    ),
+    Rule(
+      source: "った",
+      target: "う",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Past
+    ),
+    Rule(
+      source: "った",
+      target: "つ",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Past
+    ),
+    Rule(
+      source: "った",
+      target: "る",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Past
+    ),
+    Rule(
+      source: "って",
+      target: "う",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Te
+    ),
+    Rule(
+      source: "って",
+      target: "つ",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Te
+    ),
+    Rule(
+      source: "って",
+      target: "る",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Te
+    ),
+    Rule(
+      source: "てば",
+      target: "つ",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Ba
+    ),
+    Rule(
+      source: "てる",
+      target: "つ",
+      sourceConjugationGroupValue: ConjugationGroup.IchidanVerb,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Potential
+    ),
+    Rule(
+      source: "てる",
+      target: "る",
+      sourceConjugationGroupValue: ConjugationGroup.IchidanVerb,
+      targetConjugationGroupValue: ConjugationGroup.IchidanVerb | ConjugationGroup.KuruVerb,
+      reason: DeinflectionReason.Continuous
+    ),
+    Rule(
+      source: "とう",
+      target: "つ",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Volitional
+    ),
+    Rule(
+      source: "とく",
+      target: "る",
+      sourceConjugationGroupValue: ConjugationGroup.GodanVerb,
+      targetConjugationGroupValue: ConjugationGroup.IchidanVerb | ConjugationGroup.KuruVerb,
+      reason: DeinflectionReason.Toku
+    ),
+    Rule(
+      source: "ない",
+      target: "る",
+      sourceConjugationGroupValue: ConjugationGroup.IAdjective,
+      targetConjugationGroupValue: ConjugationGroup.IchidanVerb | ConjugationGroup.KuruVerb,
+      reason: DeinflectionReason.Negative
+    ),
+    Rule(
+      source: "なず",
+      target: "ぬ",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Zu
+    ),
+    Rule(
+      source: "なぬ",
+      target: "ぬ",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Negative
+    ),
+    Rule(
+      source: "なん",
+      target: "ぬ",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Negative
+    ),
+    Rule(
+      source: "ねば",
+      target: "ぬ",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Ba
+    ),
+    Rule(
+      source: "ねる",
+      target: "ぬ",
+      sourceConjugationGroupValue: ConjugationGroup.IchidanVerb,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Potential
+    ),
+    Rule(
+      source: "のう",
+      target: "ぬ",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Volitional
+    ),
+    Rule(
+      source: "ばず",
+      target: "ぶ",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Zu
+    ),
+    Rule(
+      source: "ばぬ",
+      target: "ぶ",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Negative
+    ),
+    Rule(
+      source: "ばん",
+      target: "ぶ",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Negative
+    ),
+    Rule(
+      source: "べば",
+      target: "ぶ",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Ba
+    ),
+    Rule(
+      source: "べる",
+      target: "ぶ",
+      sourceConjugationGroupValue: ConjugationGroup.IchidanVerb,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Potential
+    ),
+    Rule(
+      source: "ぼう",
+      target: "ぶ",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Volitional
+    ),
+    Rule(
+      source: "ます",
+      target: "る",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.IchidanVerb | ConjugationGroup.KuruVerb,
+      reason: DeinflectionReason.Polite
+    ),
+    Rule(
+      source: "まず",
+      target: "む",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Zu
+    ),
+    Rule(
+      source: "まぬ",
+      target: "む",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Negative
+    ),
+    Rule(
+      source: "まん",
+      target: "む",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Negative
+    ),
+    Rule(
+      source: "めば",
+      target: "む",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Ba
+    ),
+    Rule(
+      source: "める",
+      target: "む",
+      sourceConjugationGroupValue: ConjugationGroup.IchidanVerb,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Potential
+    ),
+    Rule(
+      source: "もう",
+      target: "む",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Volitional
+    ),
+    Rule(
+      source: "よう",
+      target: "る",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.IchidanVerb | ConjugationGroup.KuruVerb,
+      reason: DeinflectionReason.Volitional
+    ),
+    Rule(
+      source: "らず",
+      target: "る",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Zu
+    ),
+    Rule(
+      source: "らぬ",
+      target: "る",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Negative
+    ),
+    Rule(
+      source: "らん",
+      target: "る",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Negative
+    ),
+    Rule(
+      source: "れば",
+      target: "る",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.IchidanVerb | ConjugationGroup.GodanVerb | ConjugationGroup.KuruVerb | ConjugationGroup.SuruVerb,
+      reason: DeinflectionReason.Ba
+    ),
+    Rule(
+      source: "れる",
+      target: "る",
+      sourceConjugationGroupValue: ConjugationGroup.IchidanVerb,
+      targetConjugationGroupValue: ConjugationGroup.IchidanVerb | ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Potential
+    ),
+    Rule(
+      source: "ろう",
+      target: "る",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Volitional
+    ),
+    Rule(
+      source: "わず",
+      target: "う",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Zu
+    ),
+    Rule(
+      source: "わぬ",
+      target: "う",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Negative
+    ),
+    Rule(
+      source: "わん",
+      target: "う",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Negative
+    ),
+    Rule(
+      source: "んだ",
+      target: "ぬ",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Past
+    ),
+    Rule(
+      source: "んだ",
+      target: "ぶ",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Past
+    ),
+    Rule(
+      source: "んだ",
+      target: "む",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Past
+    ),
+    Rule(
+      source: "んで",
+      target: "ぬ",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Te
+    ),
+    Rule(
+      source: "んで",
+      target: "ぶ",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Te
+    ),
+    Rule(
+      source: "んで",
+      target: "む",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Te
+    ),
+    Rule(
+      source: "い",
+      target: "いる",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.IchidanVerb,
+      reason: DeinflectionReason.MasuStem
+    ),
+    Rule(
+      source: "い",
+      target: "う",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.MasuStem
+    ),
+    Rule(
+      source: "い",
+      target: "る",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.KuruVerb,
+      reason: DeinflectionReason.Imperative
+    ),
+    Rule(
+      source: "え",
+      target: "う",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Imperative
+    ),
+    Rule(
+      source: "え",
+      target: "える",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.IchidanVerb,
+      reason: DeinflectionReason.MasuStem
+    ),
+    Rule(
+      source: "き",
+      target: "きる",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.IchidanVerb,
+      reason: DeinflectionReason.MasuStem
+    ),
+    Rule(
+      source: "き",
+      target: "く",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.MasuStem
+    ),
+    Rule(
+      source: "き",
+      target: "くる",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.KuruVerb,
+      reason: DeinflectionReason.MasuStem
+    ),
+    Rule(
+      source: "ぎ",
+      target: "ぎる",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.IchidanVerb,
+      reason: DeinflectionReason.MasuStem
+    ),
+    Rule(
+      source: "ぎ",
+      target: "ぐ",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.MasuStem
+    ),
+    Rule(
+      source: "く",
+      target: "い",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.IAdjective,
+      reason: DeinflectionReason.Adv
+    ),
+    Rule(
+      source: "け",
+      target: "く",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Imperative
+    ),
+    Rule(
+      source: "け",
+      target: "ける",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.IchidanVerb,
+      reason: DeinflectionReason.MasuStem
+    ),
+    Rule(
+      source: "げ",
+      target: "ぐ",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Imperative
+    ),
+    Rule(
+      source: "げ",
+      target: "げる",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.IchidanVerb,
+      reason: DeinflectionReason.MasuStem
+    ),
+    Rule(
+      source: "さ",
+      target: "い",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.IAdjective,
+      reason: DeinflectionReason.Noun
+    ),
+    Rule(
+      source: "し",
+      target: "す",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.MasuStem
+    ),
+    Rule(
+      source: "じ",
+      target: "じる",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.IchidanVerb,
+      reason: DeinflectionReason.MasuStem
+    ),
+    Rule(
+      source: "ず",
+      target: "る",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.IchidanVerb | ConjugationGroup.KuruVerb,
+      reason: DeinflectionReason.Zu
+    ),
+    Rule(
+      source: "せ",
+      target: "す",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Imperative
+    ),
+    Rule(
+      source: "せ",
+      target: "せる",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.IchidanVerb,
+      reason: DeinflectionReason.MasuStem
+    ),
+    Rule(
+      source: "ぜ",
+      target: "ぜる",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.IchidanVerb,
+      reason: DeinflectionReason.MasuStem
+    ),
+    Rule(
+      source: "た",
+      target: "る",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.IchidanVerb | ConjugationGroup.KuruVerb,
+      reason: DeinflectionReason.Past
+    ),
+    Rule(
+      source: "ち",
+      target: "ちる",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.IchidanVerb,
+      reason: DeinflectionReason.MasuStem
+    ),
+    Rule(
+      source: "ち",
+      target: "つ",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.MasuStem
+    ),
+    Rule(
+      source: "て",
+      target: "つ",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Imperative
+    ),
+    Rule(
+      source: "て",
+      target: "てる",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.IchidanVerb,
+      reason: DeinflectionReason.MasuStem
+    ),
+    Rule(
+      source: "て",
+      target: "る",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.IchidanVerb | ConjugationGroup.KuruVerb,
+      reason: DeinflectionReason.Te
+    ),
+    Rule(
+      source: "で",
+      target: "でる",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.IchidanVerb,
+      reason: DeinflectionReason.MasuStem
+    ),
+    Rule(
+      source: "な",
+      target: "",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.IchidanVerb | ConjugationGroup.GodanVerb | ConjugationGroup.KuruVerb | ConjugationGroup.SuruVerb,
+      reason: DeinflectionReason.ImperativeNegative
+    ),
+    Rule(
+      source: "に",
+      target: "にる",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.IchidanVerb,
+      reason: DeinflectionReason.MasuStem
+    ),
+    Rule(
+      source: "に",
+      target: "ぬ",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.MasuStem
+    ),
+    Rule(
+      source: "ぬ",
+      target: "る",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.IchidanVerb,
+      reason: DeinflectionReason.Negative
+    ),
+    Rule(
+      source: "ん",
+      target: "る",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.IchidanVerb,
+      reason: DeinflectionReason.Negative
+    ),
+    Rule(
+      source: "ね",
+      target: "ぬ",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Imperative
+    ),
+    Rule(
+      source: "ね",
+      target: "ねる",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.IchidanVerb,
+      reason: DeinflectionReason.MasuStem
+    ),
+    Rule(
+      source: "ひ",
+      target: "ひる",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.IchidanVerb,
+      reason: DeinflectionReason.MasuStem
+    ),
+    Rule(
+      source: "び",
+      target: "びる",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.IchidanVerb,
+      reason: DeinflectionReason.MasuStem
+    ),
+    Rule(
+      source: "び",
+      target: "ぶ",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.MasuStem
+    ),
+    Rule(
+      source: "へ",
+      target: "へる",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.IchidanVerb,
+      reason: DeinflectionReason.MasuStem
+    ),
+    Rule(
+      source: "べ",
+      target: "ぶ",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Imperative
+    ),
+    Rule(
+      source: "べ",
+      target: "べる",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.IchidanVerb,
+      reason: DeinflectionReason.MasuStem
+    ),
+    Rule(
+      source: "み",
+      target: "みる",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.IchidanVerb,
+      reason: DeinflectionReason.MasuStem
+    ),
+    Rule(
+      source: "み",
+      target: "む",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.MasuStem
+    ),
+    Rule(
+      source: "め",
+      target: "む",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Imperative
+    ),
+    Rule(
+      source: "め",
+      target: "める",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.IchidanVerb,
+      reason: DeinflectionReason.MasuStem
+    ),
+    Rule(
+      source: "よ",
+      target: "る",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.IchidanVerb,
+      reason: DeinflectionReason.Imperative
+    ),
+    Rule(
+      source: "り",
+      target: "りる",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.IchidanVerb,
+      reason: DeinflectionReason.MasuStem
+    ),
+    Rule(
+      source: "り",
+      target: "る",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.MasuStem
+    ),
+    Rule(
+      source: "れ",
+      target: "る",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.GodanVerb,
+      reason: DeinflectionReason.Imperative
+    ),
+    Rule(
+      source: "れ",
+      target: "れる",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.IchidanVerb,
+      reason: DeinflectionReason.MasuStem
+    ),
+    Rule(
+      source: "ろ",
+      target: "る",
+      sourceConjugationGroupValue: ConjugationGroup.NotResultOfAnyDeinflection,
+      targetConjugationGroupValue: ConjugationGroup.IchidanVerb,
+      reason: DeinflectionReason.Imperative
+    )
+]

--- a/Reed/Tokenizer/Deinflector.swift
+++ b/Reed/Tokenizer/Deinflector.swift
@@ -1,0 +1,86 @@
+//
+//  Deinflector.swift
+//  Reed
+//
+//  Created by Shiori Yamashita on 2020/09/27.
+//  Copyright © 2020 Roger Luo. All rights reserved.
+//
+
+struct DeinflectionResult {
+    let originalText: String
+    let text: String
+    let conjugationGroupValue: ConjugationGroupValue
+    let appliedRules: [Rule]
+}
+
+class Deinflector {
+    lazy var indexedRules: [Int: [String: [Rule]]] = {
+        buildIndexedRules(rules: deinflectionRules)
+    }()
+    
+    // Build a deinflection rule dictionary keyed by the source length and source string
+    private func buildIndexedRules(rules: [Rule]) -> [Int: [String: [Rule]]] {
+        var indexedRules: [Int: [String: [Rule]]] = [:]
+        for rule in rules {
+            let sourceLength = rule.source.count
+            if indexedRules[sourceLength] == nil {
+                indexedRules[sourceLength] = [rule.source: [rule]]
+            } else {
+                if indexedRules[sourceLength]![rule.source] == nil {
+                    indexedRules[sourceLength]![rule.source] = [rule]
+                } else {
+                    indexedRules[sourceLength]![rule.source]!.append(rule)
+                }
+            }
+        }
+        return indexedRules
+    }
+    
+    // Returns an empty list if the text cannot be further deinflected
+    func deinflect(text: String) -> [DeinflectionResult] {
+        return recursivelyDeinflect(result: DeinflectionResult(
+            originalText: text,
+            text: text,
+            conjugationGroupValue: ConjugationGroup.Anything,
+            appliedRules: []
+        ))
+    }
+    
+    // TODO: Set the maximum number of recursive deinflections to avoid infinite loop
+    func recursivelyDeinflect(result: DeinflectionResult) -> [DeinflectionResult] {
+        let text = result.text
+        var allResults = [result]
+        for sourceLength in indexedRules.keys {
+            if text.count < sourceLength { continue }
+            
+            let suffix = String(text.suffix(sourceLength))
+            guard let rules = indexedRules[sourceLength]![suffix] else {
+                continue
+            }
+            
+            // Filter applicable rules by possible conjugation groups
+            let applicableRules = rules.filter {
+                $0.sourceConjugationGroupValue & result.conjugationGroupValue > 0
+            }
+            let results = applyRules(result: result, applicableRules: applicableRules)
+            
+            // Try to deinflect further
+            for result in results {
+                allResults.append(contentsOf: recursivelyDeinflect(result: result))
+            }
+        }
+        return allResults
+    }
+    
+    func applyRules(result: DeinflectionResult, applicableRules: [Rule]) -> [DeinflectionResult] {
+        let text = result.text
+        return applicableRules.map {
+            DeinflectionResult(
+                originalText: text,
+                text: String(text.prefix(text.count - $0.source.count)) + $0.target,
+                conjugationGroupValue: $0.targetConjugationGroupValue,
+                appliedRules: result.appliedRules + [$0]
+            )
+        }
+    }
+}

--- a/Reed/Tokenizer/FuriganaMaker.swift
+++ b/Reed/Tokenizer/FuriganaMaker.swift
@@ -1,0 +1,103 @@
+//
+//  FuriganaMaker.swift
+//  Reed
+//
+//  Created by Shiori Yamashita on 2020/11/18.
+//  Copyright © 2020 Roger Luo. All rights reserved.
+//
+
+import Foundation
+
+struct Furigana {
+    let range: (Int, Int)
+    let reading: String
+}
+
+class FuriganaMaker {
+    func makeFurigana(text: String, reading: String) -> [Furigana] {
+        if text.count == 0 || reading.count == 0 {
+            return []
+        }
+        let textWithoutKatakana = katakanaToHiragana(source: text)
+        let readingInHiragana = katakanaToHiragana(source: reading)
+        if !isAllHiragana(text: readingInHiragana) || textWithoutKatakana == readingInHiragana {
+            return []
+        }
+        if isAllKanji(text: text) {
+            return [Furigana(
+                range: (0, text.count),
+                reading: readingInHiragana
+            )]
+        }
+        return extractReading(text: textWithoutKatakana, reading: readingInHiragana)
+    }
+    
+    // Replace non-hiragana part with "(.+)" and return the replaced ranges
+    // Example: "犬猿の仲" -> ("(.+)の(.+)", [(0, 2), (3, 4)])
+    func getReadingPatternAndRanges(text: String) -> (String, [(Int, Int)]) {
+        let regex = try! NSRegularExpression(pattern: "[^ぁ-ん]+")
+        let range = NSRange(text.startIndex..., in: text)
+        let matches = regex.matches(
+            in: text,
+            range: range
+        )
+        let ranges = matches.map {
+            ($0.range.location, $0.range.location + $0.range.length)
+        }
+        let pattern = regex.stringByReplacingMatches(
+            in: text,
+            options: [],
+            range: range,
+            withTemplate: "(.+)"
+        )
+        return (pattern, ranges)
+    }
+    
+    func extractReading(text: String, reading: String) -> [Furigana] {
+        let (pattern, ranges) = getReadingPatternAndRanges(text: text)
+        guard let regex = try? NSRegularExpression(pattern: pattern) else {
+            return []
+        }
+
+        guard let matched = regex.firstMatch(
+            in: reading,
+            range: NSRange(location: 0, length: reading.count)
+        ) else {
+            return []
+        }
+
+        let captureGroupIndexList = Array(1...ranges.count) // Skip 0, which is the entire match
+        let matches = captureGroupIndexList.map { groupIndex -> String in
+            return (reading as NSString).substring(with: matched.range(at: groupIndex))
+        }
+        return matches.enumerated().map {
+            Furigana(
+                range: ranges[$0.offset],
+                reading: $0.element
+            )
+        }
+    }
+    
+    func isAllHiragana(text: String) -> Bool {
+        let range = "^[ぁ-ん]+$"
+        return NSPredicate(format: "SELF MATCHES %@", range).evaluate(with: text)
+    }
+    
+    func containsKanji(text: String) -> Bool {
+        let range = "[\u{3005}\u{3007}\u{303b}\u{3400}-\u{9fff}\u{f900}-\u{faff}\u{20000}-\u{2ffff}]"
+        return NSPredicate(format: "SELF MATCHES %@", range).evaluate(with: text)
+    }
+    
+    func isAllKanji(text: String) -> Bool {
+        let range = "^[\u{3005}\u{3007}\u{303b}\u{3400}-\u{9fff}\u{f900}-\u{faff}\u{20000}-\u{2ffff}]+$"
+        return NSPredicate(format: "SELF MATCHES %@", range).evaluate(with: text)
+    }
+    
+    func katakanaToHiragana(source: String) -> String {
+        if let string = source.applyingTransform(.hiraganaToKatakana, reverse: true) {
+            return string
+        } else {
+            return ""
+        }
+    }
+}

--- a/Reed/Tokenizer/MecabWordNode.swift
+++ b/Reed/Tokenizer/MecabWordNode.swift
@@ -14,28 +14,16 @@ class MecabWordNode {
     let furiganas: [Furigana]
     
     var canMakeCompoundWord: Bool {
-        guard let partOfSpeech = self.partOfSpeech,
-              let info = partOfSpeechInfo[partOfSpeech]
-        else { return false }
-        return info.canMakeCompoundWord
+        return partOfSpeech?.canMakeCompoundWord ?? false
     }
     var canStartCompoundWord: Bool {
-        guard let partOfSpeech = self.partOfSpeech,
-              let info = partOfSpeechInfo[partOfSpeech]
-        else { return false }
-        return info.canStartCompoundWord
+        return partOfSpeech?.canStartCompoundWord ?? false
     }
     var canEndCompoundWord: Bool {
-        guard let partOfSpeech = self.partOfSpeech,
-              let info = partOfSpeechInfo[partOfSpeech]
-        else { return false }
-        return info.canEndCompoundWord
+        return partOfSpeech?.canEndCompoundWord ?? false
     }
     var isYougen: Bool {
-        guard let partOfSpeech = self.partOfSpeech,
-              let info = partOfSpeechInfo[partOfSpeech]
-        else { return false }
-        return info.isYougen
+        return partOfSpeech?.isYougen ?? false
     }
     
     init(surface: String, features: [String], partOfSpeech: PartOfSpeech?, range: (Int, Int), furiganas: [Furigana]) {

--- a/Reed/Tokenizer/MecabWordNode.swift
+++ b/Reed/Tokenizer/MecabWordNode.swift
@@ -1,0 +1,61 @@
+//
+//  MecabWordNode.swift
+//  Reed
+//
+//  Created by Shiori Yamashita on 2020/11/04.
+//  Copyright © 2020 Roger Luo. All rights reserved.
+//
+
+class MecabWordNode {
+    let surface: String
+    let featureString: String?
+    let partOfSpeech: PartOfSpeech?
+    let range: (Int, Int) // [start, end)
+    
+    var canMakeCompoundWord: Bool {
+        guard let partOfSpeech = self.partOfSpeech,
+              let info = partOfSpeechInfo[partOfSpeech]
+        else { return false }
+        return info.canMakeCompoundWord
+    }
+    var canStartCompoundWord: Bool {
+        guard let partOfSpeech = self.partOfSpeech,
+              let info = partOfSpeechInfo[partOfSpeech]
+        else { return false }
+        return info.canStartCompoundWord
+    }
+    var canEndCompoundWord: Bool {
+        guard let partOfSpeech = self.partOfSpeech,
+              let info = partOfSpeechInfo[partOfSpeech]
+        else { return false }
+        return info.canEndCompoundWord
+    }
+    
+    init(surface: String, featureString: String?, partOfSpeech: PartOfSpeech?, range: (Int, Int)) {
+        self.surface = surface
+        self.featureString = featureString
+        self.partOfSpeech = partOfSpeech
+        self.range = range
+    }
+    
+    static func concatenate(_ nodes: [MecabWordNode]) -> MecabWordNode {
+        if nodes.count == 0 {
+            return MecabWordNode(
+                surface: "",
+                featureString: nil,
+                partOfSpeech: nil,
+                range: (0, 0)
+            )
+        }
+        if nodes.count == 1 {
+            return nodes.first!
+        }
+        let concatenatedSurface = nodes.map { $0.surface } .joined()
+        return MecabWordNode(
+            surface: concatenatedSurface,
+            featureString: nil,
+            partOfSpeech: nil,
+            range: (nodes.first!.range.0, nodes.last!.range.1)
+        )
+    }
+}

--- a/Reed/Tokenizer/MecabWrapper.swift
+++ b/Reed/Tokenizer/MecabWrapper.swift
@@ -1,19 +1,60 @@
 //
-//  Mecab.swift
+//  MecabWrapper.swift
 //  Reed
 //
 //  Created by Shiori Yamashita on 2020/11/02.
 //  Copyright © 2020 Roger Luo. All rights reserved.
 //
 
-let DEFAULT_JAPANESE_RESOURCES_BUNDLE_NAME = "mecab-naist-jdic-utf-8"
+let RESOURCES_BUNDLE_NAME = "mecab-naist-jdic-utf-8"
+
+enum WordType {
+    case ContentWord
+    case GrammaticalWord
+    case UnknownWord // TODO: Is it needed?
+    case Punctuation
+}
+
+struct MecabWordNode {
+    var surface: String
+    var featureString: String?
+    var range: (Int, Int) // [start, end)
+}
 
 class MecabWrapper {
-    let mecab: Mecab
+    var mecab: Mecab!
 
     init() {
-        let jpBundlePath = Bundle.main.path(forResource: DEFAULT_JAPANESE_RESOURCES_BUNDLE_NAME, ofType: "bundle")
-        let jpBundleResourcePath = Bundle.init(path: jpBundlePath!)!.resourcePath
-        mecab = Mecab.init(dicDirPath: jpBundleResourcePath!)
+        let bundlePath = Bundle.main.path(forResource: RESOURCES_BUNDLE_NAME, ofType: "bundle")
+        let bundleResourcePath = Bundle.init(path: bundlePath!)!.resourcePath
+        mecab = Mecab.init(dicDirPath: bundleResourcePath!)
+    }
+    
+    func tokenize(_ text: String) -> [MecabWordNode] {
+        guard let nodes: [MecabNode] = mecab.parseToNode(with: text) else {
+            return [MecabWordNode(
+                surface: text,
+                featureString: nil,
+                range: (0, text.count)
+            )]
+        }
+        var wordNodes = [MecabWordNode]()
+        var index = 0
+        for node in nodes {
+            let wordLength = node.surface.count
+            let leadingWhitespaceLength = Int(node.leadingWhitespaceLength)
+            let trailingWhitespaceLength = node.trailingWhitespace != nil
+                ? node.trailingWhitespace!.count
+                : 0
+            wordNodes.append(MecabWordNode(
+                surface: node.surface,
+                featureString: node.feature,
+                range: (
+                    index + leadingWhitespaceLength,
+                    index + leadingWhitespaceLength + wordLength)
+            ))
+            index += leadingWhitespaceLength + wordLength + trailingWhitespaceLength
+        }
+        return wordNodes
     }
 }

--- a/Reed/Tokenizer/MecabWrapper.swift
+++ b/Reed/Tokenizer/MecabWrapper.swift
@@ -8,13 +8,6 @@
 
 let RESOURCES_BUNDLE_NAME = "mecab-naist-jdic-utf-8"
 
-struct MecabWordNode {
-    let surface: String
-    let featureString: String?
-    let partOfSpeech: PartOfSpeech?
-    let range: (Int, Int) // [start, end)
-}
-
 class MecabWrapper {
     let mecab: Mecab
 

--- a/Reed/Tokenizer/MecabWrapper.swift
+++ b/Reed/Tokenizer/MecabWrapper.swift
@@ -1,0 +1,19 @@
+//
+//  Mecab.swift
+//  Reed
+//
+//  Created by Shiori Yamashita on 2020/11/02.
+//  Copyright © 2020 Roger Luo. All rights reserved.
+//
+
+let DEFAULT_JAPANESE_RESOURCES_BUNDLE_NAME = "mecab-naist-jdic-utf-8"
+
+class MecabWrapper {
+    let mecab: Mecab
+
+    init() {
+        let jpBundlePath = Bundle.main.path(forResource: DEFAULT_JAPANESE_RESOURCES_BUNDLE_NAME, ofType: "bundle")
+        let jpBundleResourcePath = Bundle.init(path: jpBundlePath!)!.resourcePath
+        mecab = Mecab.init(dicDirPath: jpBundleResourcePath!)
+    }
+}

--- a/Reed/Tokenizer/PartOfSpeech.swift
+++ b/Reed/Tokenizer/PartOfSpeech.swift
@@ -22,6 +22,7 @@ enum PartOfSpeech: String {
 }
 
 struct PartOfSpeechInfo {
+    let isYougen: Bool
     let canMakeCompoundWord: Bool
     let canStartCompoundWord: Bool
     let canEndCompoundWord: Bool
@@ -29,61 +30,73 @@ struct PartOfSpeechInfo {
 
 let partOfSpeechInfo: [PartOfSpeech: PartOfSpeechInfo] = [
     PartOfSpeech.Adjective: PartOfSpeechInfo(
+        isYougen: true,
         canMakeCompoundWord: true,
         canStartCompoundWord: true,
         canEndCompoundWord: true
     ),
     PartOfSpeech.Adnominal: PartOfSpeechInfo(
+        isYougen: false,
         canMakeCompoundWord: true,
         canStartCompoundWord: true,
         canEndCompoundWord: false
     ),
     PartOfSpeech.Adverb: PartOfSpeechInfo(
+        isYougen: false,
         canMakeCompoundWord: true,
         canStartCompoundWord: true,
         canEndCompoundWord: true
     ),
     PartOfSpeech.Auxiliary: PartOfSpeechInfo(
+        isYougen: false,
         canMakeCompoundWord: true,
         canStartCompoundWord: false,
         canEndCompoundWord: true
     ),
     PartOfSpeech.Conjunction: PartOfSpeechInfo(
+        isYougen: false,
         canMakeCompoundWord: true,
         canStartCompoundWord: true,
         canEndCompoundWord: true
     ),
     PartOfSpeech.Filler: PartOfSpeechInfo(
+        isYougen: false,
         canMakeCompoundWord: true,
         canStartCompoundWord: true,
         canEndCompoundWord: true
     ),
     PartOfSpeech.Interjection: PartOfSpeechInfo(
+        isYougen: false,
         canMakeCompoundWord: true,
         canStartCompoundWord: true,
         canEndCompoundWord: true
     ),
     PartOfSpeech.Noun: PartOfSpeechInfo(
+        isYougen: false,
         canMakeCompoundWord: true,
         canStartCompoundWord: true,
         canEndCompoundWord: true
     ),
     PartOfSpeech.PostpositionalParticle: PartOfSpeechInfo(
+        isYougen: false,
         canMakeCompoundWord: true,
         canStartCompoundWord: false,
         canEndCompoundWord: false
     ),
     PartOfSpeech.Prefix: PartOfSpeechInfo(
+        isYougen: false,
         canMakeCompoundWord: true,
         canStartCompoundWord: true,
         canEndCompoundWord: false
     ),
     PartOfSpeech.Symbol: PartOfSpeechInfo(
+        isYougen: false,
         canMakeCompoundWord: false,
         canStartCompoundWord: false,
         canEndCompoundWord: false
     ),
     PartOfSpeech.Verb: PartOfSpeechInfo(
+        isYougen: true,
         canMakeCompoundWord: true,
         canStartCompoundWord: true,
         canEndCompoundWord: true

--- a/Reed/Tokenizer/PartOfSpeech.swift
+++ b/Reed/Tokenizer/PartOfSpeech.swift
@@ -1,0 +1,91 @@
+//
+//  WordTypes.swift
+//  Reed
+//
+//  Created by Shiori Yamashita on 2020/11/04.
+//  Copyright © 2020 Roger Luo. All rights reserved.
+//
+
+enum PartOfSpeech: String {
+    case Adjective = "形容詞"
+    case Adnominal = "連体詞"
+    case Adverb = "副詞"
+    case Auxiliary = "助動詞"
+    case Conjunction = "接続詞"
+    case Filler = "フィラー"
+    case Interjection = "感動詞"
+    case Noun = "名詞"
+    case PostpositionalParticle = "助詞"
+    case Prefix = "接頭詞"
+    case Symbol = "記号"
+    case Verb = "動詞"
+}
+
+struct PartOfSpeechInfo {
+    let canMakeCompoundWord: Bool
+    let canStartCompoundWord: Bool
+    let canEndCompoundWord: Bool
+}
+
+let partOfSpeechInfo: [PartOfSpeech: PartOfSpeechInfo] = [
+    PartOfSpeech.Adjective: PartOfSpeechInfo(
+        canMakeCompoundWord: true,
+        canStartCompoundWord: true,
+        canEndCompoundWord: true
+    ),
+    PartOfSpeech.Adnominal: PartOfSpeechInfo(
+        canMakeCompoundWord: true,
+        canStartCompoundWord: true,
+        canEndCompoundWord: false
+    ),
+    PartOfSpeech.Adverb: PartOfSpeechInfo(
+        canMakeCompoundWord: true,
+        canStartCompoundWord: true,
+        canEndCompoundWord: true
+    ),
+    PartOfSpeech.Auxiliary: PartOfSpeechInfo(
+        canMakeCompoundWord: true,
+        canStartCompoundWord: false,
+        canEndCompoundWord: true
+    ),
+    PartOfSpeech.Conjunction: PartOfSpeechInfo(
+        canMakeCompoundWord: true,
+        canStartCompoundWord: true,
+        canEndCompoundWord: true
+    ),
+    PartOfSpeech.Filler: PartOfSpeechInfo(
+        canMakeCompoundWord: true,
+        canStartCompoundWord: true,
+        canEndCompoundWord: true
+    ),
+    PartOfSpeech.Interjection: PartOfSpeechInfo(
+        canMakeCompoundWord: true,
+        canStartCompoundWord: true,
+        canEndCompoundWord: true
+    ),
+    PartOfSpeech.Noun: PartOfSpeechInfo(
+        canMakeCompoundWord: true,
+        canStartCompoundWord: true,
+        canEndCompoundWord: true
+    ),
+    PartOfSpeech.PostpositionalParticle: PartOfSpeechInfo(
+        canMakeCompoundWord: true,
+        canStartCompoundWord: false,
+        canEndCompoundWord: false
+    ),
+    PartOfSpeech.Prefix: PartOfSpeechInfo(
+        canMakeCompoundWord: true,
+        canStartCompoundWord: true,
+        canEndCompoundWord: false
+    ),
+    PartOfSpeech.Symbol: PartOfSpeechInfo(
+        canMakeCompoundWord: false,
+        canStartCompoundWord: false,
+        canEndCompoundWord: false
+    ),
+    PartOfSpeech.Verb: PartOfSpeechInfo(
+        canMakeCompoundWord: true,
+        canStartCompoundWord: true,
+        canEndCompoundWord: true
+    )
+]

--- a/Reed/Tokenizer/PartOfSpeech.swift
+++ b/Reed/Tokenizer/PartOfSpeech.swift
@@ -19,86 +19,40 @@ enum PartOfSpeech: String {
     case Prefix = "接頭詞"
     case Symbol = "記号"
     case Verb = "動詞"
+    
+    var canMakeCompoundWord: Bool {
+        switch self {
+        case .Symbol:
+            return false
+        default:
+            return true
+        }
+    }
+    
+    var canStartCompoundWord: Bool {
+        switch self {
+        case .Auxiliary, .PostpositionalParticle, .Symbol:
+            return false
+        default:
+            return true
+        }
+    }
+    
+    var canEndCompoundWord: Bool {
+        switch self {
+        case .Adnominal, .PostpositionalParticle, .Prefix, .Symbol:
+            return false
+        default:
+            return true
+        }
+    }
+    
+    var isYougen: Bool {
+        switch self {
+        case .Adjective, .Verb:
+            return true
+        default:
+            return false
+        }
+    }
 }
-
-struct PartOfSpeechInfo {
-    let isYougen: Bool
-    let canMakeCompoundWord: Bool
-    let canStartCompoundWord: Bool
-    let canEndCompoundWord: Bool
-}
-
-let partOfSpeechInfo: [PartOfSpeech: PartOfSpeechInfo] = [
-    PartOfSpeech.Adjective: PartOfSpeechInfo(
-        isYougen: true,
-        canMakeCompoundWord: true,
-        canStartCompoundWord: true,
-        canEndCompoundWord: true
-    ),
-    PartOfSpeech.Adnominal: PartOfSpeechInfo(
-        isYougen: false,
-        canMakeCompoundWord: true,
-        canStartCompoundWord: true,
-        canEndCompoundWord: false
-    ),
-    PartOfSpeech.Adverb: PartOfSpeechInfo(
-        isYougen: false,
-        canMakeCompoundWord: true,
-        canStartCompoundWord: true,
-        canEndCompoundWord: true
-    ),
-    PartOfSpeech.Auxiliary: PartOfSpeechInfo(
-        isYougen: false,
-        canMakeCompoundWord: true,
-        canStartCompoundWord: false,
-        canEndCompoundWord: true
-    ),
-    PartOfSpeech.Conjunction: PartOfSpeechInfo(
-        isYougen: false,
-        canMakeCompoundWord: true,
-        canStartCompoundWord: true,
-        canEndCompoundWord: true
-    ),
-    PartOfSpeech.Filler: PartOfSpeechInfo(
-        isYougen: false,
-        canMakeCompoundWord: true,
-        canStartCompoundWord: true,
-        canEndCompoundWord: true
-    ),
-    PartOfSpeech.Interjection: PartOfSpeechInfo(
-        isYougen: false,
-        canMakeCompoundWord: true,
-        canStartCompoundWord: true,
-        canEndCompoundWord: true
-    ),
-    PartOfSpeech.Noun: PartOfSpeechInfo(
-        isYougen: false,
-        canMakeCompoundWord: true,
-        canStartCompoundWord: true,
-        canEndCompoundWord: true
-    ),
-    PartOfSpeech.PostpositionalParticle: PartOfSpeechInfo(
-        isYougen: false,
-        canMakeCompoundWord: true,
-        canStartCompoundWord: false,
-        canEndCompoundWord: false
-    ),
-    PartOfSpeech.Prefix: PartOfSpeechInfo(
-        isYougen: false,
-        canMakeCompoundWord: true,
-        canStartCompoundWord: true,
-        canEndCompoundWord: false
-    ),
-    PartOfSpeech.Symbol: PartOfSpeechInfo(
-        isYougen: false,
-        canMakeCompoundWord: false,
-        canStartCompoundWord: false,
-        canEndCompoundWord: false
-    ),
-    PartOfSpeech.Verb: PartOfSpeechInfo(
-        isYougen: true,
-        canMakeCompoundWord: true,
-        canStartCompoundWord: true,
-        canEndCompoundWord: true
-    )
-]

--- a/Reed/Tokenizer/PartOfSpeechMatcher.swift
+++ b/Reed/Tokenizer/PartOfSpeechMatcher.swift
@@ -1,0 +1,186 @@
+//
+//  PartOfSpeechMatcher.swift
+//  Reed
+//
+//  Created by Shiori Yamashita on 2020/11/08.
+//  Copyright © 2020 Roger Luo. All rights reserved.
+//
+
+enum PartOfSpeechMatchLevel {
+    case Primary
+    case Secondary
+    case None
+}
+
+struct PartOfSpeechConversionDestination {
+    let primary: [String]
+    let secondary: [String]
+}
+
+// "記号" is not converted
+let partOfSpeechConversion: [String: Any] = [
+    "その他": PartOfSpeechConversionDestination(
+        primary: ["prt", "cop", "exp", "int", "unc"],
+        secondary: []
+    ),
+    "フィラー": PartOfSpeechConversionDestination(
+        primary: ["conj", "exp", "int"],
+        secondary: []
+    ),
+    "感動詞": PartOfSpeechConversionDestination(
+        primary: ["conj", "exp", "int"],
+        secondary: []
+    ),
+    "形容詞": PartOfSpeechConversionDestination(
+        primary: ["adj-f", "adj-i", "adj-ix", "adj-kari", "adj-ku", "adj-shiku"],
+        secondary: ["adj-na", "adj-nari", "adj-no", "adj-pn", "adj-t", "aux-adj"]
+    ),
+    // TODO: 格助詞の連語やばい
+    "助詞": PartOfSpeechConversionDestination(
+        primary: ["prt"],
+        secondary: ["aux", "aux-adj", "aux-v", "conj", "cop"]
+    ),
+    "助動詞": PartOfSpeechConversionDestination(
+        primary: ["aux", "aux-adj", "aux-v", "cop"],
+        secondary: ["v-unspec"]
+    ),
+    "接続詞": PartOfSpeechConversionDestination(
+        primary: ["conj"],
+        secondary: ["int", "exp"]
+    ),
+    "接頭詞": PartOfSpeechConversionDestination(
+        primary: ["pref", "n-pref"],
+        secondary: ["adj-f", "adj-pn"]
+    ),
+    "動詞": PartOfSpeechConversionDestination(
+        primary: [
+            "v-unspec",
+            "v1", "v1-s",
+            "v2a-s", "v2b-k", "v2b-s", "v2d-k", "v2d-s", "v2g-k", "v2g-s", "v2h-k", "v2h-s", "v2k-k", "v2k-s", "v2m-k", "v2m-s", "v2n-s", "v2r-k", "v2r-s", "v2s-s", "v2t-k", "v2t-s", "v2w-s", "v2y-k", "v2y-s", "v2z-s",
+            "v4b", "v4g", "v4h", "v4k", "v4m", "v4n", "v4r", "v4s", "v4t",
+            "v5aru", "v5b", "v5g", "v5k", "v5k-s", "v5m", "v5n", "v5r", "v5r-i", "v5s", "v5t", "v5u", "v5u-s", "v5uru",
+            "vi", "vk", "vn", "vr", "vs", "vs-c", "vs-i", "vs-s", "vt", "vz"
+        ],
+        secondary: ["adj-f", "exp"]
+    ),
+    "副詞": PartOfSpeechConversionDestination(
+        primary: ["adv", "adv-to"],
+        secondary: ["n-t"]
+    ),
+    "名詞": [
+        "サ変接続": PartOfSpeechConversionDestination(
+            primary: ["vs", "n"],
+            secondary: []
+        ),
+        // Becomes "adj-i" when followed by "ない"
+        "ナイ形容詞語幹": PartOfSpeechConversionDestination(
+            primary: ["vs"],
+            secondary: ["adj-i", "adj-ku"]
+        ),
+        "一般": PartOfSpeechConversionDestination(
+            primary: ["n", "n-adv", "adj-f", "adj-na", "adj-nari", "adj-no", "adj-t", "adv-to"],
+            secondary: ["suf", "n-suf", "adv", "ctr", "exp", "int", "unc", "vs"]
+        ),
+        "引用文字列": PartOfSpeechConversionDestination(
+            primary: ["n"],
+            secondary: []
+        ),
+        "形容動詞語幹": PartOfSpeechConversionDestination(
+            primary: ["adj-na", "adj-nari", "adj-no"],
+            secondary: ["adj-t", "adj-to", "n"]
+        ),
+        "固有名詞": PartOfSpeechConversionDestination(
+            primary: ["n"],
+            secondary: []
+        ),
+        "数": PartOfSpeechConversionDestination(
+            primary: ["num"],
+            secondary: ["n", "ctr", "pref"]
+        ),
+        "接続詞的": PartOfSpeechConversionDestination(
+            primary: ["n", "conj"],
+            secondary: []
+        ),
+        "接尾": PartOfSpeechConversionDestination(
+            primary: ["suf", "n", "n-suf"],
+            secondary: ["prt"]
+        ),
+        "代名詞": PartOfSpeechConversionDestination(
+            primary: ["pn"],
+            secondary: ["n-adv", "n", "n-t"]
+        ),
+        "動詞非自立的": PartOfSpeechConversionDestination(
+            primary: ["n", "vs", "int", "exp"],
+            secondary: []
+        ),
+        // Assuming its only subgroup is "助動詞語幹"
+        "特殊": PartOfSpeechConversionDestination(
+            primary: ["aux", "adj-na"],
+            secondary: []
+        ),
+        "非自立": PartOfSpeechConversionDestination(
+            primary: ["n", "n-suf", "suf", "adj-na", "aux"],
+            secondary: []
+        ),
+        "副詞可能": PartOfSpeechConversionDestination(
+            primary: ["n-t", "n-adv"],
+            secondary: ["n"]
+        ),
+    ],
+    "連体詞": PartOfSpeechConversionDestination(
+        primary: ["adj-f", "adj-pn"],
+        secondary: []
+    ),
+    "*": PartOfSpeechConversionDestination(
+        primary: ["unc"],
+        secondary: []
+    ),
+]
+
+// TODO: Needs some caching
+class PartOfSpeechMatcher {
+    
+    func match(features: [String], jmdictPartsOfSpeech: [String]) -> PartOfSpeechMatchLevel {
+        if features.isEmpty || jmdictPartsOfSpeech.isEmpty {
+            return PartOfSpeechMatchLevel.None
+        }
+        
+        let conversionDestination = convert(features: features)
+        let isPrimary = jmdictPartsOfSpeech.contains { conversionDestination.primary.contains($0) }
+        if isPrimary {
+            return PartOfSpeechMatchLevel.Primary
+        }
+        let isSecondary = jmdictPartsOfSpeech.contains { conversionDestination.secondary.contains($0) }
+        if isSecondary {
+            return PartOfSpeechMatchLevel.Secondary
+        }
+        return PartOfSpeechMatchLevel.None
+    }
+    
+    func convert(features: [String]) -> PartOfSpeechConversionDestination {
+        let destination = recursivelyConvert(
+            features: features,
+            conversionMap: partOfSpeechConversion
+        )
+        // TODO: Do this somewhere else
+        return PartOfSpeechConversionDestination(
+            primary: destination.primary.map { "&" + $0 + ";" },
+            secondary: destination.secondary.map { "&" + $0 + ";" }
+        )
+    }
+
+    func recursivelyConvert(features: [String], conversionMap: [String: Any]) -> PartOfSpeechConversionDestination {
+        let firstFeature = features.first!
+        let isKey = conversionMap.keys.contains(firstFeature)
+        let value = conversionMap[isKey ? firstFeature : "*"]
+        if value is PartOfSpeechConversionDestination {
+            return value as! PartOfSpeechConversionDestination
+        } else {
+            return recursivelyConvert(
+                features: Array(features[1 ..< features.endIndex]),
+                conversionMap: value as! [String: Any]
+            )
+        }
+    }
+    
+}

--- a/Reed/Tokenizer/Tokenizer.swift
+++ b/Reed/Tokenizer/Tokenizer.swift
@@ -1,0 +1,129 @@
+//
+//  Tokenizer.swift
+//  Reed
+//
+//  Created by Shiori Yamashita on 2020/11/04.
+//  Copyright © 2020 Roger Luo. All rights reserved.
+//
+
+struct Token {
+    let surface: String
+    let dictionaryEntry: DictionaryEntry?
+    let mecabWordNodes: [MecabWordNode]
+    let deinflectionResult: DeinflectionResult?
+    let range: (Int, Int)
+}
+
+class Tokenizer {
+    let MAXIMUM_CONCATENATION = 4
+    
+    let dictionaryFetcher: DictionaryFetcher
+    let mecabWrapper: MecabWrapper
+    let deinflector: Deinflector
+    
+    init() {
+        dictionaryFetcher = DictionaryFetcher()
+        mecabWrapper = MecabWrapper()
+        deinflector = Deinflector()
+    }
+    
+    func tokenize(_ text: String) -> [Token] {
+        let mecabWordNodes = mecabWrapper.tokenize(text)
+        let phrases = separateIntoPhrases(nodes: mecabWordNodes)
+        var tokens = [Token]()
+        for phrase in phrases {
+            tokens.append(contentsOf: tokenizeSinglePhrase(nodes: phrase))
+        }
+        return tokens
+    }
+    
+    func separateIntoPhrases(nodes: [MecabWordNode]) -> [[MecabWordNode]] {
+        var phrases = [[MecabWordNode]]()
+        var isPreviousNodePhraseBoundary = true
+        for node in nodes {
+            if node.canMakeCompoundWord {
+                if isPreviousNodePhraseBoundary {
+                    phrases.append([node])
+                } else {
+                    phrases[phrases.count - 1].append(node)
+                }
+                isPreviousNodePhraseBoundary = false
+            } else {
+                phrases.append([node])
+                isPreviousNodePhraseBoundary = true
+            }
+        }
+        return phrases
+    }
+    
+    func tokenizeSinglePhrase(nodes: [MecabWordNode]) -> [Token] {
+        var tokens = [Token]()
+        
+        var startIndex = 0
+        let tokenCount = nodes.endIndex
+        while startIndex < tokenCount {
+            let firstNode = nodes[startIndex]
+            if !firstNode.canStartCompoundWord {
+                let (dictionaryEntry, deinflectionResult) = fetchDictionaryEntry(
+                    text: firstNode.surface
+                )
+                tokens.append(Token(
+                    surface: firstNode.surface,
+                    dictionaryEntry: dictionaryEntry,
+                    mecabWordNodes: [firstNode],
+                    deinflectionResult: deinflectionResult,
+                    range: firstNode.range
+                ))
+                startIndex += 1
+                continue
+            }
+            for concatenationCount in stride(from: MAXIMUM_CONCATENATION, to: 0, by: -1) {
+                let endIndex = min(startIndex + concatenationCount, tokenCount)
+                let lastNode = nodes[endIndex - 1]
+                
+                if !lastNode.canEndCompoundWord && concatenationCount > 1 { continue }
+                
+                let nodesToBeConcatenated = Array(nodes[startIndex ..< endIndex])
+                let concatenatedToken = MecabWordNode.concatenate(nodesToBeConcatenated)
+                let (dictionaryEntry, deinflectionResult) = fetchDictionaryEntry(
+                    text: concatenatedToken.surface
+                )
+                if concatenationCount == 1 || dictionaryEntry != nil {
+                    tokens.append(Token(
+                        surface: concatenatedToken.surface,
+                        dictionaryEntry: dictionaryEntry,
+                        mecabWordNodes: nodesToBeConcatenated,
+                        deinflectionResult: deinflectionResult,
+                        range: concatenatedToken.range
+                    ))
+                    startIndex += concatenationCount
+                    break
+                }
+            }
+        }
+        
+        return tokens
+    }
+
+    // TODO: The entry with least deinflection and most characters should be picked
+    func fetchDictionaryEntry(text: String) -> (DictionaryEntry?, DeinflectionResult?) {
+        var entry: DictionaryEntry?
+        var deinflectionResult: DeinflectionResult?
+        
+        let deinflectionResults = deinflector.deinflect(text: text)
+        for result in deinflectionResults {
+            let entries = dictionaryFetcher.fetchEntries(of: result.text)
+            if entries.isEmpty { continue }
+            let bestEntry = entries.first
+            if entry == nil {
+                entry = bestEntry
+                deinflectionResult = result
+            } else {
+                entry = bestEntry
+                deinflectionResult = result
+            }
+        }
+        
+        return (entry, deinflectionResult)
+    }
+}

--- a/ReedTests/Tokenizer/DeinflectorTests.swift
+++ b/ReedTests/Tokenizer/DeinflectorTests.swift
@@ -1,0 +1,29 @@
+//
+//  DeinflectorTests.swift
+//  ReedTests
+//
+//  Created by Shiori Yamashita on 2020/11/17.
+//  Copyright © 2020 Roger Luo. All rights reserved.
+//
+
+import XCTest
+@testable import Reed
+
+class DeinflectorTests: XCTestCase {
+    var deinflector: Deinflector!
+
+    override func setUp() {
+        super.setUp()
+        
+        deinflector = Deinflector()
+    }
+
+    func testDeinflect() {
+        let deinflectionResults = deinflector.deinflect(text: "踊りたくなかった")
+        let correctDeinflectionResult = deinflectionResults.first(where: {
+            $0.text == "踊る"
+        })
+        XCTAssertNotNil(correctDeinflectionResult)
+    }
+
+}

--- a/ReedTests/Tokenizer/FuriganaMakerTests.swift
+++ b/ReedTests/Tokenizer/FuriganaMakerTests.swift
@@ -1,0 +1,70 @@
+//
+//  FuriganaMakerTests.swift
+//  ReedTests
+//
+//  Created by Shiori Yamashita on 2020/11/18.
+//  Copyright © 2020 Roger Luo. All rights reserved.
+//
+
+import XCTest
+@testable import Reed
+
+class FuriganaMakerTests: XCTestCase {
+    var furiganaMaker: FuriganaMaker!
+    
+    override func setUp() {
+        super.setUp()
+        
+        furiganaMaker = FuriganaMaker()
+    }
+    
+    func testMakeFurigana() {
+        let allKanjiFuriganas = furiganaMaker.makeFurigana(text: "洗浄", reading: "センジョウ")
+        XCTAssertTrue(allKanjiFuriganas[0].range == (0, 2))
+        XCTAssertEqual(allKanjiFuriganas[0].reading, "せんじょう")
+        
+        let noKanjiFuriganas = furiganaMaker.makeFurigana(text: "たれパンダ", reading: "タレパンダ")
+        XCTAssertTrue(noKanjiFuriganas.isEmpty)
+        
+        let partiallyKanjiFuriganas = furiganaMaker.makeFurigana(text: "手伝う", reading: "テツダウ")
+        XCTAssertTrue(partiallyKanjiFuriganas[0].range == (0, 2))
+        XCTAssertEqual(partiallyKanjiFuriganas[0].reading, "てつだ")
+        
+        let symbolFuriganas = furiganaMaker.makeFurigana(text: "(", reading: "\"(\"")
+        XCTAssertTrue(symbolFuriganas.isEmpty)
+    }
+    
+    func testGetReadingPatternAndCount() {
+        let (pattern, ranges) = furiganaMaker.getReadingPatternAndRanges(text: "百聞は一見に如かず")
+        XCTAssertEqual(pattern, "(.+)は(.+)に(.+)かず")
+        XCTAssertTrue(ranges[0] == (0, 2))
+        XCTAssertTrue(ranges[1] == (3, 5))
+        XCTAssertTrue(ranges[2] == (6, 7))
+    }
+    
+    func testExtractReading() {
+        let furiganas = furiganaMaker.extractReading(text: "百聞は一見に如かず", reading: "ひゃくぶんはいっけんにしかず")
+        XCTAssertTrue(furiganas[0].range == (0, 2))
+        XCTAssertEqual(furiganas[0].reading, "ひゃくぶん")
+        XCTAssertTrue(furiganas[1].range == (3, 5))
+        XCTAssertEqual(furiganas[1].reading, "いっけん")
+        XCTAssertTrue(furiganas[2].range == (6, 7))
+        XCTAssertEqual(furiganas[2].reading, "し")
+    }
+
+    func testKatakanaToHiragana() {
+        XCTAssertEqual(
+            furiganaMaker.katakanaToHiragana(source: "アイウエオ"),
+            "あいうえお"
+        )
+        XCTAssertEqual(
+            furiganaMaker.katakanaToHiragana(source: "123ア123"),
+            "123あ123"
+        )
+        XCTAssertEqual(
+            furiganaMaker.katakanaToHiragana(source: "生麦なまごめナマタマゴ"),
+            "生麦なまごめなまたまご"
+        )
+    }
+
+}

--- a/ReedTests/Tokenizer/PartOfSpeechMatcherTests.swift
+++ b/ReedTests/Tokenizer/PartOfSpeechMatcherTests.swift
@@ -1,0 +1,41 @@
+//
+//  PartOfSpeechMatcherTests.swift
+//  ReedTests
+//
+//  Created by Shiori Yamashita on 2020/11/14.
+//  Copyright © 2020 Roger Luo. All rights reserved.
+//
+
+import XCTest
+@testable import Reed
+
+class PartOfSpeechMatcherTests: XCTestCase {
+    var matcher: PartOfSpeechMatcher!
+    
+    override func setUp() {
+        super.setUp()
+        
+        matcher = PartOfSpeechMatcher()
+    }
+    
+    func testMatch() throws {
+        let primary = matcher.match(
+            features: ["名詞", "非自立", "一般", "*", "*", "*"],
+            jmdictPartsOfSpeech: ["&n;"]
+        )
+        XCTAssertEqual(primary, PartOfSpeechMatchLevel.Primary)
+        
+        let secondary = matcher.match(
+            features: ["接頭詞", "名詞接続", "*", "*", "*", "*"],
+            jmdictPartsOfSpeech: ["&n;", "&adj-pn;"]
+        )
+        XCTAssertEqual(secondary, PartOfSpeechMatchLevel.Secondary)
+        
+        let none = matcher.match(
+            features: ["接頭詞", "名詞接続", "*", "*", "*", "*"],
+            jmdictPartsOfSpeech: ["&int;", "&exp;"]
+        )
+        XCTAssertEqual(none, PartOfSpeechMatchLevel.None)
+    }
+
+}

--- a/ReedTests/Tokenizer/TokenizerTests.swift
+++ b/ReedTests/Tokenizer/TokenizerTests.swift
@@ -1,0 +1,44 @@
+//
+//  TokenizerTests.swift
+//  ReedTests
+//
+//  Created by Shiori Yamashita on 2020/11/16.
+//  Copyright © 2020 Roger Luo. All rights reserved.
+//
+
+import XCTest
+@testable import Reed
+
+class TokenizerTests: XCTestCase {
+    var tokenizer: Tokenizer!
+
+    override func setUp() {
+        super.setUp()
+        tokenizer = Tokenizer()
+    }
+
+    func testTokenize() {
+        let tokens = tokenizer.tokenize("予算ゼロ！？　錬金術協会で基礎研究をしていましたが、退職して学生時代の友人(女騎士)の辺境開発を手伝うことにしました。")
+        printTokens(tokens: tokens)
+    }
+    
+    func printTokens(tokens: [Token]) {
+        for token in tokens {
+            print("=============================")
+            print(token.surface)
+            print("range: " + String(token.range.0) + "-" + String(token.range.1))
+            print("------- mecabWordNodes ------")
+            dump(token.mecabWordNodes)
+            print("----- deinflectionResult ----")
+            dump(token.deinflectionResult)
+            print("--- dictionaryDefinitions ---")
+            for definition in token.dictionaryDefinitions {
+                print(definition.partsOfSpeech.joined(separator: ", "))
+                print(definition.glosses.joined(separator: "; "))
+            }
+            print("--------- furiganas ---------")
+            dump(token.furiganas)
+        }
+    }
+
+}


### PR DESCRIPTION
![Reed_Tokenizer](https://user-images.githubusercontent.com/29548429/99728871-efa0e400-2a6e-11eb-9bad-dbed71592568.png)

`Tokenizer` can be used like so:
```
let someString: String = ""
let tokenizer: Tokenizer()
let tokens: [Token] = tokenizer.tokenize(someString)
```
Where, notably, the token contains the indices that it spans in the original string and its furigana readings if applicable, among other data. One token can have multiple `Furigana` nodes because a term can have kana in between kanji (eg. 読み方 would have two nodes). Each `Furigana` contains the relevant reading as well as the range it spans in its respective term.