### PR TITLE
Rawger/Definer: Address crash bug in definer, fix spacing.

### DIFF
--- a/Reed/Definer/views/DefinerTab.swift
+++ b/Reed/Definer/views/DefinerTab.swift
@@ -14,60 +14,62 @@ struct DefinerTab: View {
     var body: some View {
         ScrollView {
             VStack {
-                HStack(alignment: .lastTextBaseline) {
+                HStack(alignment: .lastTextBaseline, spacing: 16) {
                     Text(entry.title)
                         .font(.title2)
-                        .padding(.horizontal)
                     Text("\(entry.primaryReading)")
                         .font(.footnote)
-                        .foregroundColor(.gray)
                         .padding(.trailing)
                     Spacer()
                 }
-                .padding(.vertical)
+                .padding(.vertical, 4)
                 
-                ForEach(0..<entry.definitions.endIndex, id: \.self) { i in
-                    HStack(alignment: .firstTextBaseline) {
-                        Text("\(i + 1).")
-                            .frame(width: 35, alignment: .trailing)
-                        HStack(alignment: .lastTextBaseline) {
-                            Text(entry.definitions[i].definition)
-                                .padding(.trailing)
-                                .fixedSize(horizontal: false, vertical: true)
-                            Text("\(entry.definitions[i].specicificLexemes)")
-                                .font(.footnote)
-                                .foregroundColor(.gray)
-                                .padding(.trailing)
-                            Spacer()
+                VStack(alignment: .leading, spacing: 8) {
+                    ForEach(0..<entry.definitions.endIndex, id: \.self) { i in
+                        HStack(alignment: .firstTextBaseline) {
+                            Text("\(i + 1).")
+                                .frame(width: 35, alignment: .trailing)
+                            HStack(alignment: .lastTextBaseline, spacing: 8) {
+                                Text(entry.definitions[i].definition)
+                                    .fixedSize(horizontal: false, vertical: true)
+                                Text("\(entry.definitions[i].specicificLexemes)")
+                                    .font(.footnote)
+                                    .foregroundColor(Color(.systemGray3))
+                                Spacer()
+                            }
                         }
                     }
-                    .padding(.bottom, 4)
                 }
+                .padding(.leading, -20)
+                .padding(.bottom, 12)
                 
                 if !entry.terms.isEmpty {
-                    VStack{
-                        Color.gray.frame(height: 1)
-                        HStack {
-                            Text("OTHER FORMS")
-                                .font(.headline)
-                                .foregroundColor(.gray)
-                            Spacer()
-                        }
-                    }
-                    .padding()
-                }
-                
-                ForEach(entry.terms, id: \.self) { term in
-                    HStack(alignment: .lastTextBaseline) {
-                        Text("\(term.term)")
-                            .padding(.horizontal)
-                        Text("\(term.reading)")
-                            .font(.footnote)
-                            .foregroundColor(.gray)
-                            .padding(.trailing)
+                    Divider()
+                    
+                    HStack {
+                        Text("OTHER FORMS")
+                            .font(.subheadline)
+                            .fontWeight(.bold)
+                            .foregroundColor(Color(.systemGray4))
                         Spacer()
                     }
                     .padding(.bottom, 4)
+                    
+                    VStack(alignment: .leading, spacing: 8) {
+                        ForEach(entry.terms, id: \.self) { term in
+                            HStack(alignment: .lastTextBaseline) {
+                                Text("\(term.term)")
+                                    .padding(.horizontal)
+                                Text("\(term.reading)")
+                                    .font(.footnote)
+                                    .foregroundColor(Color(.systemGray3))
+                                    .padding(.trailing)
+                                Spacer()
+                            }
+                            .padding(.bottom, 4)
+                        }
+                    }
+                    .padding(.leading, -16)
                 }
             }
         }

--- a/Reed/Definer/views/DefinerTab.swift
+++ b/Reed/Definer/views/DefinerTab.swift
@@ -9,7 +9,7 @@
 import SwiftUI
 
 struct DefinerTab: View {
-    var entry: DefinitionDetails
+    let entry: DefinitionDetails
     
     var body: some View {
         ScrollView {
@@ -23,7 +23,8 @@ struct DefinerTab: View {
                         .foregroundColor(.gray)
                         .padding(.trailing)
                     Spacer()
-                }.padding(.vertical)
+                }
+                .padding(.vertical)
                 
                 ForEach(0..<entry.definitions.endIndex, id: \.self) { i in
                     HStack(alignment: .firstTextBaseline) {

--- a/Reed/Definer/views/DefinerView.swift
+++ b/Reed/Definer/views/DefinerView.swift
@@ -32,6 +32,7 @@ struct DefinerView: View {
                     tabViewId = UUID()
                 }
                 .id(tabViewId)
+                .padding(.horizontal)
             }
         }
         .ignoresSafeArea()

--- a/Reed/Definer/views/DefinerView.swift
+++ b/Reed/Definer/views/DefinerView.swift
@@ -20,17 +20,19 @@ struct DefinerView: View {
             isOpen: self.$isBottomSheetExpanded,
             maxHeight: 400)
         {
-            TabView(selection: $definitionEntryIndex) {
-                ForEach(entries, id: \.self) { entry in
-                    DefinerTab(entry: entry)
+            if !entries.isEmpty {
+                TabView(selection: $definitionEntryIndex) {
+                    ForEach(entries, id: \.self) { entry in
+                        DefinerTab(entry: entry)
+                    }
                 }
+                .tabViewStyle(PageTabViewStyle())
+                .onChange(of: entries) { value in
+                    definitionEntryIndex = 0
+                    tabViewId = UUID()
+                }
+                .id(tabViewId)
             }
-            .tabViewStyle(PageTabViewStyle())
-            .onChange(of: entries) { value in
-                definitionEntryIndex = 0
-                tabViewId = UUID()
-            }
-            .id(tabViewId)
         }
         .ignoresSafeArea()
     }

--- a/Reed/Reader/views/ReaderView.swift
+++ b/Reed/Reader/views/ReaderView.swift
@@ -12,7 +12,6 @@ import SwiftUIPager
 struct ReaderView: View {
     @ObservedObject var viewModel: ReaderViewModel
     @State private var entries = [DefinitionDetails]()
-    @State private var page: Int = 0
 
     init(ncode: String) {
         self.viewModel = ReaderViewModel(ncode: ncode)


### PR DESCRIPTION
Commit 1: Fix reader crash on launch
Fixes a bug where the Reader crashes the app on launch. This error was caused by the Definer's TabView trying to render when it has no children. We fix this issue by rendering the paginated TabView only when entries is not empty.

Commit 2: Correct spacing and color.
Corrects some padding and color inconsistencies with the Figma, and uses lightly refactors in favor of more generalized padding convention. In particular, this commit imposes a universal horizontal padding on the entire DefinerView, uses `spacing` rather than padding when possible, and uses appropriate degrees of `systemGrayX` instead of the standard `Color.gray`.

<img src="https://user-images.githubusercontent.com/29548429/100533825-82ebbf00-31bd-11eb-9e92-cf48f145a5a8.png" width="50%"/>
