### PR TITLE
Rawger/NovelDetails: Implement NovelDetails high-fidelity.

### DIFF
--- a/Reed.xcodeproj/project.pbxproj
+++ b/Reed.xcodeproj/project.pbxproj
@@ -73,6 +73,8 @@
 		B8A5E50E2527BACE003BCF07 /* UtilsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8A5E50D2527BACE003BCF07 /* UtilsTests.swift */; };
 		B8A78F072542F26700577974 /* DiscoverList.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8A78F062542F26700577974 /* DiscoverList.swift */; };
 		B8A78F0C2542F27200577974 /* DiscoverListItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8A78F0B2542F27200577974 /* DiscoverListItem.swift */; };
+		B8ADEAB52570E0CC007C3D28 /* View+readSize.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8ADEAB42570E0CC007C3D28 /* View+readSize.swift */; };
+		B8ADEABA2570E205007C3D28 /* FlexView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8ADEAB92570E205007C3D28 /* FlexView.swift */; };
 		B8B8F9912526C10400D6DF8B /* DictionaryFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8B8F9902526C10400D6DF8B /* DictionaryFetcher.swift */; };
 		B8C88D7C256F9FC0006CD768 /* DictionaryUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8C88D7B256F9FC0006CD768 /* DictionaryUtils.swift */; };
 		B8D041C125667C18003F1E05 /* DeinflectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8D041C025667C18003F1E05 /* DeinflectorTests.swift */; };
@@ -188,6 +190,8 @@
 		B8A5E50D2527BACE003BCF07 /* UtilsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UtilsTests.swift; sourceTree = "<group>"; };
 		B8A78F062542F26700577974 /* DiscoverList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscoverList.swift; sourceTree = "<group>"; };
 		B8A78F0B2542F27200577974 /* DiscoverListItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscoverListItem.swift; sourceTree = "<group>"; };
+		B8ADEAB42570E0CC007C3D28 /* View+readSize.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+readSize.swift"; sourceTree = "<group>"; };
+		B8ADEAB92570E205007C3D28 /* FlexView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlexView.swift; sourceTree = "<group>"; };
 		B8B8F9902526C10400D6DF8B /* DictionaryFetcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictionaryFetcher.swift; sourceTree = "<group>"; };
 		B8C88D7B256F9FC0006CD768 /* DictionaryUtils.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DictionaryUtils.swift; sourceTree = "<group>"; };
 		B8D041C025667C18003F1E05 /* DeinflectorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DeinflectorTests.swift; sourceTree = "<group>"; };
@@ -332,11 +336,12 @@
 			isa = PBXGroup;
 			children = (
 				B82AF5FB2548031F00FAB2A8 /* SearchBar.swift */,
-				B82AF5FC2548031F00FAB2A8 /* ViewControllerResolver.swift */,
-				B82AF5DC2548015B00FAB2A8 /* View+UIKitComponents.swift */,
 				B8FA93BD254BBE0D00AE362C /* NavigationLazyView.swift */,
 				6D9EC86625723B8B00CD4833 /* DefinableTextView.swift */,
 				6D4F99B72556A0C900CC0DF6 /* BottomSheetView.swift */,
+				B82AF5FC2548031F00FAB2A8 /* ViewControllerResolver.swift */,
+				B82AF5DC2548015B00FAB2A8 /* View+UIKitComponents.swift */,
+				B8ADEAB92570E205007C3D28 /* FlexView.swift */,
 			);
 			path = Components;
 			sourceTree = "<group>";
@@ -454,6 +459,7 @@
 		B8981109250F803F0059F71F /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
+				B8ADEAB42570E0CC007C3D28 /* View+readSize.swift */,
 				B898110A250F81600059F71F /* NSManagedObject+Init.swift */,
 				B80E0E74254A225B009B0EE8 /* UINavigationController+UIGestureRecognizerDelegate.swift */,
 			);
@@ -914,6 +920,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				B8ADEABA2570E205007C3D28 /* FlexView.swift in Sources */,
 				B86550CF255A08D800E4786F /* HistoryEntry+CoreDataClass.swift in Sources */,
 				B8F5C20E250EDDB2000810F8 /* DictionaryEntry+CoreDataProperties.swift in Sources */,
 				B8F5C20F250EDDB2000810F8 /* DictionaryReading+CoreDataClass.swift in Sources */,
@@ -940,6 +947,7 @@
 				B8D456D62508DD24000F9E5F /* LibraryEntryView.swift in Sources */,
 				B80CBD272542887700C807CD /* DiscoverListItemViewModel.swift in Sources */,
 				B80E0E7025497EBA009B0EE8 /* DiscoverSearchResultsViewModel.swift in Sources */,
+				B8ADEAB52570E0CC007C3D28 /* View+readSize.swift in Sources */,
 				B898110B250F81600059F71F /* NSManagedObject+Init.swift in Sources */,
 				B8D4569F2508D1A2000F9E5F /* Reed.xcdatamodeld in Sources */,
 				6D1298EE257239E400E873F4 /* HistorySection+CoreDataProperties.swift in Sources */,

--- a/Reed/Components/DefinableTextView.swift
+++ b/Reed/Components/DefinableTextView.swift
@@ -33,10 +33,10 @@ struct DefinitionDetails: Equatable, Hashable, Identifiable {
 }
 
 struct DefinableTextView: UIViewRepresentable {
-    let text: String!
+    @Binding var text: String
     let definerResultHandler: ([DefinitionDetails]) -> Void
     
-    func makeUIView(context: UIViewRepresentableContext<DefinableTextView>) -> UIView {
+    func makeUIView(context: UIViewRepresentableContext<DefinableTextView>) -> UITextView {
         let textView = UITextView()
         textView.isEditable = false
         textView.isSelectable = false
@@ -44,8 +44,21 @@ struct DefinableTextView: UIViewRepresentable {
         textView.contentSize = CGSize(width: UIScreen.main.bounds.width * 0.9, height: UIScreen.main.bounds.height * 0.6)
         textView.font = .systemFont(ofSize: 17)
         textView.textAlignment = .justified
-        textView.addGestureRecognizer(UITapGestureRecognizer(target: context.coordinator, action: #selector(Coordinator.wordTapped(gesture:))))
+        textView.addGestureRecognizer(
+            UITapGestureRecognizer(
+                target: context.coordinator,
+                action: #selector(Coordinator.wordTapped(gesture:))
+            )
+        )
         return textView
+    }
+    
+    func updateUIView(_ textView: UITextView, context: UIViewRepresentableContext<DefinableTextView>) {
+        textView.text = text
+    }
+    
+    func makeCoordinator() -> DefinableTextView.Coordinator {
+        return Coordinator(definerResultHandler: definerResultHandler)
     }
     
     class Coordinator: NSObject {
@@ -63,7 +76,11 @@ struct DefinableTextView: UIViewRepresentable {
             let location = gesture.location(in: textView)
             let position = CGPoint(x: location.x + textView.font!.pointSize / 2, y: location.y)
             let tapPosition = textView.closestPosition(to: position)
-            tappedRange = textView.tokenizer.rangeEnclosingPosition(tapPosition!, with: UITextGranularity.word, inDirection: UITextDirection(rawValue: 1))
+            tappedRange = textView.tokenizer.rangeEnclosingPosition(
+                tapPosition!,
+                with: UITextGranularity.word,
+                inDirection: UITextDirection(rawValue: 1)
+            )
             if let tappedRange = tappedRange {
                 if let tappedWord = textView.text(in: tappedRange) {
                     highlightSelection(textView: textView)
@@ -122,10 +139,4 @@ struct DefinableTextView: UIViewRepresentable {
             textView.textStorage.addAttribute(NSAttributedString.Key.backgroundColor, value: UIColor.lightGray, range: selectedRange!)
         }
     }
-    
-    func makeCoordinator() -> DefinableTextView.Coordinator {
-        return Coordinator(definerResultHandler: definerResultHandler)
-    }
-    
-    func updateUIView(_ uiView: UIView, context: UIViewRepresentableContext<DefinableTextView>) {}
 }

--- a/Reed/Components/FlexView.swift
+++ b/Reed/Components/FlexView.swift
@@ -1,0 +1,83 @@
+//
+//  FlexView.swift
+//  Reed
+//
+//  Created by Roger Luo on 11/26/20.
+//  Copyright © 2020 Roger Luo. All rights reserved.
+//
+
+import SwiftUI
+
+// https://fivestars.blog/swiftui/flexible-swiftui.html
+struct FlexView<Data: Collection, Content: View>: View where Data.Element: Hashable {
+    let data: Data
+    let spacing: CGFloat
+    let alignment: HorizontalAlignment
+    let content: (Data.Element) -> Content
+    @State private var availableWidth: CGFloat = 0
+    
+    var body: some View {
+        ZStack(alignment: Alignment(horizontal: alignment, vertical: .center)) {
+            Color.clear
+                .frame(height: 1)
+                .readSize { size in
+                    availableWidth = size.width
+                }
+            
+            FlexViewContent(
+                availableWidth: availableWidth,
+                data: data,
+                spacing: spacing,
+                alignment: alignment,
+                content: content
+            )
+        }
+    }
+}
+
+fileprivate struct FlexViewContent<Data: Collection, Content: View>: View where Data.Element: Hashable {
+    let availableWidth: CGFloat
+    let data: Data
+    let spacing: CGFloat
+    let alignment: HorizontalAlignment
+    let content: (Data.Element) -> Content
+    @State var elementsSize: [Data.Element: CGSize] = [:]
+    
+    var body : some View {
+        VStack(alignment: alignment, spacing: spacing) {
+            ForEach(computeRows(), id: \.self) { rowElements in
+                HStack(spacing: spacing) {
+                    ForEach(rowElements, id: \.self) { element in
+                        content(element)
+                            .fixedSize()
+                            .readSize { size in
+                                elementsSize[element] = size
+                            }
+                    }
+                }
+            }
+        }
+    }
+    
+    func computeRows() -> [[Data.Element]] {
+        var rows: [[Data.Element]] = [[]]
+        var currentRow = 0
+        var remainingWidth = availableWidth
+        
+        for element in data {
+            let elementSize = elementsSize[element, default: CGSize(width: availableWidth, height: 1)]
+            
+            if remainingWidth - (elementSize.width + spacing) >= 0 {
+                rows[currentRow].append(element)
+            } else {
+                currentRow = currentRow + 1
+                rows.append([element])
+                remainingWidth = availableWidth
+            }
+            
+            remainingWidth = remainingWidth - (elementSize.width + spacing)
+        }
+        
+        return rows
+    }
+}

--- a/Reed/DiscoverTab/DiscoverView.swift
+++ b/Reed/DiscoverTab/DiscoverView.swift
@@ -57,6 +57,7 @@ struct DiscoverView: View {
                 hidesWhenScrolling: false
             )
         }
+        .navigationViewStyle(StackNavigationViewStyle())
     }
 }
 

--- a/Reed/Extensions/View+readSize.swift
+++ b/Reed/Extensions/View+readSize.swift
@@ -1,0 +1,27 @@
+//
+//  View+readSize.swift
+//  Reed
+//
+//  Created by Roger Luo on 11/26/20.
+//  Copyright © 2020 Roger Luo. All rights reserved.
+//
+
+import SwiftUI
+
+// https://fivestars.blog/swiftui/swiftui-share-layout-information.html
+extension View {
+    func readSize(onChange: @escaping (CGSize) -> Void) -> some View {
+        background(
+            GeometryReader { geometryProxy in
+                Color.clear
+                  .preference(key: SizePreferenceKey.self, value: geometryProxy.size)
+            }
+        )
+        .onPreferenceChange(SizePreferenceKey.self, perform: onChange)
+    }
+}
+
+private struct SizePreferenceKey: PreferenceKey {
+    static var defaultValue: CGSize = .zero
+    static func reduce(value: inout CGSize, nextValue: () -> CGSize) {}
+}

--- a/Reed/NovelDetails/viewmodels/NovelDetailsViewModel.swift
+++ b/Reed/NovelDetails/viewmodels/NovelDetailsViewModel.swift
@@ -75,6 +75,20 @@ class NovelDetailsViewModel: ObservableObject {
             }
         }
     }
+    
+    // TODO: Perhaps pass the historyEntry directly to Reader?
+    func onPushToReader() {
+        if historyEntry != nil { return }
+        
+        historyEntry = HistoryEntry.create(
+            context: persistentContainer.viewContext,
+            ncode: novelNcode,
+            title: novelTitle,
+            author: novelAuthor,
+            subgenre: novelSubgenre!.rawValue,
+            isFavorite: false
+        )
+    }
 }
 
 // Unwrap and postprocess NarouResponse optionals for readability

--- a/Reed/NovelDetails/viewmodels/NovelDetailsViewModel.swift
+++ b/Reed/NovelDetails/viewmodels/NovelDetailsViewModel.swift
@@ -64,7 +64,7 @@ class NovelDetailsViewModel: ObservableObject {
             model.addFavorite(
                 title: novelTitle,
                 author: novelAuthor,
-                subgenre: novelSubgenre
+                subgenre: novelSubgenre!.rawValue
             ) { historyEntryId in
                 if let historyEntryId = historyEntryId {
                     self.historyEntry = try? self.persistentContainer.viewContext.existingObject(
@@ -79,10 +79,6 @@ class NovelDetailsViewModel: ObservableObject {
 
 // Unwrap and postprocess NarouResponse optionals for readability
 extension NovelDetailsViewModel {
-    var novelAuthor: String {
-        novelData?.author ?? ""
-    }
-    
     var novelNcode: String {
         novelData?.ncode ?? ""
     }
@@ -91,11 +87,19 @@ extension NovelDetailsViewModel {
         novelData?.title ?? ""
     }
     
-    var novelSubgenre: Int {
-        novelData?.subgenre?.rawValue ?? Subgenre.none.rawValue
+    var novelAuthor: String {
+        novelData?.author ?? ""
+    }
+    
+    var novelSubgenre: Subgenre? {
+        novelData?.subgenre
     }
     
     var novelSynopsis: String {
         novelData?.synopsis?.trimmingCharacters(in: ["\n"]) ?? ""
+    }
+    
+    var novelKeywords: [String] {
+        novelData?.keyword ?? []
     }
 }

--- a/Reed/NovelDetails/views/NovelDetailsView.swift
+++ b/Reed/NovelDetails/views/NovelDetailsView.swift
@@ -12,6 +12,7 @@ struct NovelDetailsView: View {
     @ObservedObject var viewModel: NovelDetailsViewModel
     @State private var topExpanded: Bool = true
     @State private var entries: [DefinitionDetails] = []
+    @State private var isPushedToReader: Bool = false
     
     init(ncode: String) {
         viewModel = NovelDetailsViewModel(ncode: ncode)
@@ -35,14 +36,26 @@ struct NovelDetailsView: View {
                     .padding(.bottom, 16)
                     
                     HStack(spacing: 8) {
-                        Button(action: {}) {
-                            Text("Read")
-                                .frame(width: 72, height: 32)
-                                .foregroundColor(.white)
-                                .background(Color(.systemBlue))
-                                .cornerRadius(4)
+                        Button(action: {
+                            viewModel.onPushToReader()
+                            isPushedToReader = true
+                        }) {
+                            ZStack {
+                                NavigationLink(
+                                    destination: NavigationLazyView(ReaderView(ncode: viewModel.ncode)),
+                                    isActive: $isPushedToReader
+                                ) { EmptyView() }
+                                
+                                Text("Read")
+                                    .frame(width: 72, height: 32)
+                                    .foregroundColor(.white)
+                                    .background(Color(.systemBlue))
+                                    .cornerRadius(4)
+                            }
                         }
                         .buttonStyle(PlainButtonStyle())
+                        .disabled(viewModel.isLibraryDataLoading)
+                        
                         Button(action: viewModel.toggleFavorite) {
                             Image(systemName: viewModel.isFavorite ? "star.fill" : "star")
                         }

--- a/Reed/NovelDetails/views/NovelDetailsView.swift
+++ b/Reed/NovelDetails/views/NovelDetailsView.swift
@@ -10,29 +10,77 @@ import SwiftUI
 
 struct NovelDetailsView: View {
     @ObservedObject var viewModel: NovelDetailsViewModel
+    @State private var topExpanded: Bool = true
+    @State private var entries: [DefinitionDetails] = []
     
     init(ncode: String) {
         viewModel = NovelDetailsViewModel(ncode: ncode)
     }
     
     var body: some View {
-        ScrollView(.vertical, showsIndicators: false) {
-            VStack(alignment: .leading, spacing: .zero) {
-                Text(viewModel.novelTitle)
-                    .font(.title3)
-                    .fontWeight(.medium)
-                Spacer()
-                
-                Text("Synopsis")
-                    .font(.headline)
-                Text(viewModel.novelSynopsis)
-                    .font(.subheadline)
-                
-                Button(action: viewModel.toggleFavorite) {
-                    Image(systemName: viewModel.isFavorite ? "heart.fill" : "heart")
+        ZStack {
+            ScrollView(.vertical, showsIndicators: false) {
+                VStack(alignment: .leading, spacing: 0) {
+                    Text(viewModel.novelTitle)
+                        .font(.title)
+                        .padding(.top, 12)
+                        .padding(.bottom, 4)
+
+                    HStack(spacing: .zero) {
+                        Text(viewModel.novelAuthor)
+                        Text("｜")
+                            .foregroundColor(.gray)
+                        Text(viewModel.novelSubgenre?.nameJp ?? "")
+                    }
+                    .padding(.bottom, 16)
+                    
+                    HStack(spacing: 8) {
+                        Button(action: {}) {
+                            Text("Read")
+                                .frame(width: 72, height: 32)
+                                .foregroundColor(.white)
+                                .background(Color(.systemBlue))
+                                .cornerRadius(4)
+                        }
+                        .buttonStyle(PlainButtonStyle())
+                        Button(action: viewModel.toggleFavorite) {
+                            Image(systemName: viewModel.isFavorite ? "star.fill" : "star")
+                        }
+                        .disabled(viewModel.isLibraryDataLoading)
+                    }
+                    .padding(.bottom, 24)
+                    
+                    Group {
+                        Text("SYNOPSIS")
+                            .font(.subheadline).bold()
+                            .foregroundColor(Color(.systemGray4))
+                            .padding(.bottom, 4)
+                        Text(viewModel.novelSynopsis)
+                    }
+                    .padding(.bottom, 8)
+                    
+                    FlexView(
+                        data: viewModel.novelKeywords,
+                        spacing: 8,
+                        alignment: .leading,
+                        content: { keyword in
+                            Text(keyword)
+                                .font(.body)
+                                .foregroundColor(Color(.systemBlue))
+                                .padding(.horizontal, 8)
+                                .padding(.vertical, 4)
+                                .overlay(
+                                    RoundedRectangle(cornerRadius: 4)
+                                        .stroke(Color(.systemBlue))
+                                )
+                        }
+                    )
+                    .padding(.leading, 1)
                 }
-                .disabled(viewModel.isLibraryDataLoading)
             }
+            .padding(.horizontal)
+
+            DefinerView(entries: self.$entries)
         }
         .navigationBarTitle("", displayMode: .inline)
     }

--- a/Reed/Reader/views/ReaderView.swift
+++ b/Reed/Reader/views/ReaderView.swift
@@ -25,7 +25,10 @@ struct ReaderView: View {
                     data: viewModel.pages,
                     id: \.self,
                     content: { text in
-                        DefinableTextView(text: text, definerResultHandler: definerResultHandler)
+                        DefinableTextView(
+                            text: .constant(text),
+                            definerResultHandler: definerResultHandler
+                        )
                     }
                 )
                 .onPageChanged { page in


### PR DESCRIPTION
Commit 1: Introducing FlexViewComponent
Introduces an extension on View to get the view of any size. This readView function is then used to build a new component called the FlexView, which can be abstractly considered a wrapping HStack.

Commit 2: General UI for NovelDetailsView.
Implements the general layout for the NovelDetailsView. Since the DefinableTextView cannot render within a ScrollView, definition functionality cannot be implemented until the DefinableTextView supports scrolling.

Commit 3: Push from NovelDetailsView to ReaderView.
Implements the functionality for a NovelDetailsView to push to a ReaderView. Prior to making the transition, the NovelDetailsView creates a HistoryEntry if it doesn't exist already, and ReaderView will fetch the corresponding HistoryEntry. We also add StackNavigationViewStyle to the DiscoverView's NavigationView in order to suppress a doubleColumn warning.