### PR TITLE
Rawger/{NovelDetails, Reader, Definer}: Hiding tabs and set sizes.

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -2,6 +2,7 @@ platform :ios, '14.0'
 
 target 'Reed' do
   pod 'GzipSwift'
+  pod 'Introspect'
   pod 'SwiftyJSON'
   pod 'SwiftUIPager'
   pod 'SwiftyNarou'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,5 +1,6 @@
 PODS:
   - GzipSwift (5.1.1)
+  - Introspect (0.1.1)
   - mecab-ko (0.4.0)
   - mecab-naist-jdic-utf-8 (0.1.3)
   - SwiftSoup (2.3.2)
@@ -12,6 +13,7 @@ PODS:
 
 DEPENDENCIES:
   - GzipSwift
+  - Introspect
   - mecab-ko
   - mecab-naist-jdic-utf-8
   - SwiftUIPager
@@ -21,6 +23,7 @@ DEPENDENCIES:
 SPEC REPOS:
   trunk:
     - GzipSwift
+    - Introspect
     - mecab-ko
     - mecab-naist-jdic-utf-8
     - SwiftSoup
@@ -30,6 +33,7 @@ SPEC REPOS:
 
 SPEC CHECKSUMS:
   GzipSwift: 893f3e48e597a1a4f62fafcb6514220fcf8287fa
+  Introspect: 50c17d6b1f091f4cfd678ea8a4157ac071808fe3
   mecab-ko: 45633c9b839e8e1f025cd1895ca943de5b3e0efa
   mecab-naist-jdic-utf-8: 0df05453d30e5774bf28f019eb45507fc8a4f740
   SwiftSoup: f97bc4e988c7729d6457f9642f974c617a6e2510
@@ -37,6 +41,6 @@ SPEC CHECKSUMS:
   SwiftyJSON: 36413e04c44ee145039d332b4f4e2d3e8d6c4db7
   SwiftyNarou: 216efd79d945f2a7f0d98b843ccf1f35680ffe94
 
-PODFILE CHECKSUM: 3a38352df33c432bff9ce11757de40b500228a58
+PODFILE CHECKSUM: 142f4fbbdd16e1fa598e549f8752e3846261b915
 
 COCOAPODS: 1.10.0

--- a/Reed.xcodeproj/xcshareddata/xcschemes/Reed.xcscheme
+++ b/Reed.xcodeproj/xcshareddata/xcschemes/Reed.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1200"
+   LastUpgradeVersion = "1220"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Reed/Components/BottomSheetView.swift
+++ b/Reed/Components/BottomSheetView.swift
@@ -13,7 +13,8 @@ fileprivate enum Constants {
     static let indicatorHeight: CGFloat = 2
     static let indicatorWidth: CGFloat = 32
     static let snapRatio: CGFloat = 0.25
-    static let minHeightRatio: CGFloat = 0.5
+    static let minHeight: CGFloat = 120
+    static let maxHeight: CGFloat = UIScreen.main.bounds.height * 0.4
 }
 
 struct BottomSheetView<Content: View>: View {
@@ -23,9 +24,9 @@ struct BottomSheetView<Content: View>: View {
     let minHeight: CGFloat
     let content: Content
     
-    init(isOpen: Binding<Bool>, maxHeight: CGFloat, @ViewBuilder content: () -> Content) {
-        self.minHeight = maxHeight * Constants.minHeightRatio
-        self.maxHeight = maxHeight
+    init(isOpen: Binding<Bool>, @ViewBuilder content: () -> Content) {
+        self.minHeight = Constants.minHeight
+        self.maxHeight = Constants.maxHeight
         self.content = content()
         self._isOpen = isOpen
     }

--- a/Reed/Definer/views/DefinerView.swift
+++ b/Reed/Definer/views/DefinerView.swift
@@ -16,10 +16,7 @@ struct DefinerView: View {
     @State private var tabViewId = UUID()
     
     var body: some View {
-        BottomSheetView (
-            isOpen: self.$isBottomSheetExpanded,
-            maxHeight: 400)
-        {
+        BottomSheetView (isOpen: self.$isBottomSheetExpanded) {
             if !entries.isEmpty {
                 TabView(selection: $definitionEntryIndex) {
                     ForEach(entries, id: \.self) { entry in

--- a/Reed/NovelDetails/views/NovelDetailsView.swift
+++ b/Reed/NovelDetails/views/NovelDetailsView.swift
@@ -7,12 +7,14 @@
 //
 
 import SwiftUI
+import Introspect
 
 struct NovelDetailsView: View {
     @ObservedObject var viewModel: NovelDetailsViewModel
     @State private var topExpanded: Bool = true
     @State private var entries: [DefinitionDetails] = []
     @State private var isPushedToReader: Bool = false
+    @State private var tabBar: UITabBar?
     
     init(ncode: String) {
         viewModel = NovelDetailsViewModel(ncode: ncode)
@@ -92,6 +94,11 @@ struct NovelDetailsView: View {
                 }
             }
             .padding(.horizontal)
+            .introspectTabBarController { tabBarController in
+                tabBar = tabBarController.tabBar
+                self.tabBar?.isHidden = true
+            }
+            .onDisappear { self.tabBar?.isHidden = false }
 
             DefinerView(entries: self.$entries)
         }

--- a/Reed/Reader/views/ReaderView.swift
+++ b/Reed/Reader/views/ReaderView.swift
@@ -7,11 +7,13 @@
 //
 
 import SwiftUI
+import Introspect
 import SwiftUIPager
 
 struct ReaderView: View {
     @ObservedObject var viewModel: ReaderViewModel
     @State private var entries = [DefinitionDetails]()
+    @State private var tabBar: UITabBar?
 
     init(ncode: String) {
         self.viewModel = ReaderViewModel(ncode: ncode)
@@ -48,6 +50,11 @@ struct ReaderView: View {
             DefinerView(entries: $entries)
         }
         .navigationBarHidden(true)
+        .introspectTabBarController { tabBarController in
+            tabBar = tabBarController.tabBar
+            self.tabBar?.isHidden = true
+        }
+        .onDisappear { self.tabBar?.isHidden = false }
     }
     
     func definerResultHandler(newEntries: [DefinitionDetails]) {


### PR DESCRIPTION
Commit 1: Hiding tab bar.
This commit imports the SwiftUI Introspect library, which allows us to easily access the underlying UIKit components in SwiftUI. Introspect is then used in the Reader view and NovelDetails to hide the tab bar, which was originally obstructing part of the Definer. Furthermore, with the tab bar hidden, the bottom sheet nature of the Definer now appears to render from the bottom of the screen rather than sprout from the tab bar.

The implementation hides the tab bar in NovelDetails and Reader by setting `UITabBarController.tabBar.isHidden` to be `true`, and then setting that value to `false` in the view's `onDisappear` lifecycle method to ensure that parent views do not lose their TabBar when the Reader or NovelDetails view pops.

Commit 2: Setting Definer height
For the Definer, imposes a constant min height and a dynamic max height, calculated as a ratio of the screen's height.

Definer at initial min height:
![Screen Shot 2020-12-02 at 12 12 16 AM](https://user-images.githubusercontent.com/29548429/100846472-6bb60700-3433-11eb-97be-f6180c940a20.png)

Definer at full height:
![Screen Shot 2020-12-02 at 12 16 11 AM](https://user-images.githubusercontent.com/29548429/100846656-9ef89600-3433-11eb-81e9-2d08c4532318.png)
