### PR TITLE
Shiori/Tokenizer: Use NSRange instead of tuple

### DIFF
--- a/Reed/Tokenizer/FuriganaMaker.swift
+++ b/Reed/Tokenizer/FuriganaMaker.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 struct Furigana {
-    let range: (Int, Int)
+    let range: NSRange
     let reading: String
 }
 
@@ -25,7 +25,7 @@ class FuriganaMaker {
         }
         if isAllKanji(text: text) {
             return [Furigana(
-                range: (0, text.count),
+                range: NSMakeRange(0, text.count),
                 reading: readingInHiragana
             )]
         }
@@ -34,16 +34,14 @@ class FuriganaMaker {
     
     // Replace non-hiragana part with "(.+)" and return the replaced ranges
     // Example: "犬猿の仲" -> ("(.+)の(.+)", [(0, 2), (3, 4)])
-    func getReadingPatternAndRanges(text: String) -> (String, [(Int, Int)]) {
+    func getReadingPatternAndRanges(text: String) -> (String, [NSRange]) {
         let regex = try! NSRegularExpression(pattern: "[^ぁ-ん]+")
         let range = NSRange(text.startIndex..., in: text)
         let matches = regex.matches(
             in: text,
             range: range
         )
-        let ranges = matches.map {
-            ($0.range.location, $0.range.location + $0.range.length)
-        }
+        let ranges = matches.map { $0.range }
         let pattern = regex.stringByReplacingMatches(
             in: text,
             options: [],

--- a/Reed/Tokenizer/MecabWordNode.swift
+++ b/Reed/Tokenizer/MecabWordNode.swift
@@ -10,7 +10,7 @@ class MecabWordNode {
     let surface: String
     let features: [String]
     let partOfSpeech: PartOfSpeech?
-    let range: (Int, Int) // [start, end)
+    let range: NSRange
     let furiganas: [Furigana]
     
     var canMakeCompoundWord: Bool {
@@ -26,7 +26,7 @@ class MecabWordNode {
         return partOfSpeech?.isYougen ?? false
     }
     
-    init(surface: String, features: [String], partOfSpeech: PartOfSpeech?, range: (Int, Int), furiganas: [Furigana]) {
+    init(surface: String, features: [String], partOfSpeech: PartOfSpeech?, range: NSRange, furiganas: [Furigana]) {
         self.surface = surface
         self.features = features
         self.partOfSpeech = partOfSpeech
@@ -40,7 +40,7 @@ class MecabWordNode {
                 surface: "",
                 features: [],
                 partOfSpeech: nil,
-                range: (0, 0),
+                range: NSMakeRange(0, 0),
                 furiganas: []
             )
         }
@@ -52,7 +52,7 @@ class MecabWordNode {
             surface: concatenatedSurface,
             features: [],
             partOfSpeech: nil,
-            range: (nodes.first!.range.0, nodes.last!.range.1),
+            range: NSUnionRange(nodes.first!.range, nodes.last!.range),
             furiganas: concatenateFuriganas(of: nodes)
         )
     }
@@ -64,12 +64,12 @@ class MecabWordNode {
             concatenatedFuriganas.append(
                 contentsOf: node.furiganas.map {
                     Furigana(
-                        range: ($0.range.0 + offset, $0.range.1 + offset),
+                        range: NSMakeRange($0.range.location + offset, $0.range.length),
                         reading: $0.reading
                     )
                 }
             )
-            offset += node.range.1 - node.range.0
+            offset += node.range.length
         }
         return concatenatedFuriganas
     }

--- a/Reed/Tokenizer/MecabWrapper.swift
+++ b/Reed/Tokenizer/MecabWrapper.swift
@@ -25,7 +25,7 @@ class MecabWrapper {
                 surface: text,
                 features: [],
                 partOfSpeech: nil,
-                range: (0, text.count),
+                range: NSMakeRange(0, text.count),
                 furiganas: []
             )]
         }
@@ -40,10 +40,7 @@ class MecabWrapper {
                 surface: node.surface,
                 features: features,
                 partOfSpeech: convertFeatureStringToPartOfSpeech(node.feature),
-                range: (
-                    index + leadingWhitespaceLength,
-                    index + leadingWhitespaceLength + wordLength
-                ),
+                range: NSMakeRange(index + leadingWhitespaceLength, wordLength),
                 furiganas: features.count >= 8
                     ? furiganaMaker.makeFurigana(text: node.surface, reading: features[7])
                     : []

--- a/Reed/Tokenizer/Tokenizer.swift
+++ b/Reed/Tokenizer/Tokenizer.swift
@@ -11,7 +11,7 @@ struct Token {
     let dictionaryDefinitions: [DictionaryDefinition]
     let mecabWordNodes: [MecabWordNode]
     let deinflectionResult: DeinflectionResult?
-    let range: (Int, Int)
+    let range: NSRange
     let furiganas: [Furigana]
 }
 

--- a/ReedTests/Tokenizer/FuriganaMakerTests.swift
+++ b/ReedTests/Tokenizer/FuriganaMakerTests.swift
@@ -20,14 +20,14 @@ class FuriganaMakerTests: XCTestCase {
     
     func testMakeFurigana() {
         let allKanjiFuriganas = furiganaMaker.makeFurigana(text: "洗浄", reading: "センジョウ")
-        XCTAssertTrue(allKanjiFuriganas[0].range == (0, 2))
+        XCTAssertTrue(NSEqualRanges(allKanjiFuriganas[0].range, NSMakeRange(0, 2)))
         XCTAssertEqual(allKanjiFuriganas[0].reading, "せんじょう")
         
         let noKanjiFuriganas = furiganaMaker.makeFurigana(text: "たれパンダ", reading: "タレパンダ")
         XCTAssertTrue(noKanjiFuriganas.isEmpty)
         
         let partiallyKanjiFuriganas = furiganaMaker.makeFurigana(text: "手伝う", reading: "テツダウ")
-        XCTAssertTrue(partiallyKanjiFuriganas[0].range == (0, 2))
+        XCTAssertTrue(NSEqualRanges(partiallyKanjiFuriganas[0].range, NSMakeRange(0, 2)))
         XCTAssertEqual(partiallyKanjiFuriganas[0].reading, "てつだ")
         
         let symbolFuriganas = furiganaMaker.makeFurigana(text: "(", reading: "\"(\"")
@@ -37,18 +37,18 @@ class FuriganaMakerTests: XCTestCase {
     func testGetReadingPatternAndCount() {
         let (pattern, ranges) = furiganaMaker.getReadingPatternAndRanges(text: "百聞は一見に如かず")
         XCTAssertEqual(pattern, "(.+)は(.+)に(.+)かず")
-        XCTAssertTrue(ranges[0] == (0, 2))
-        XCTAssertTrue(ranges[1] == (3, 5))
-        XCTAssertTrue(ranges[2] == (6, 7))
+        XCTAssertTrue(NSEqualRanges(ranges[0], NSMakeRange(0, 2)))
+        XCTAssertTrue(NSEqualRanges(ranges[1], NSMakeRange(3, 2)))
+        XCTAssertTrue(NSEqualRanges(ranges[2], NSMakeRange(6, 1)))
     }
     
     func testExtractReading() {
         let furiganas = furiganaMaker.extractReading(text: "百聞は一見に如かず", reading: "ひゃくぶんはいっけんにしかず")
-        XCTAssertTrue(furiganas[0].range == (0, 2))
+        XCTAssertTrue(NSEqualRanges(furiganas[0].range, NSMakeRange(0, 2)))
         XCTAssertEqual(furiganas[0].reading, "ひゃくぶん")
-        XCTAssertTrue(furiganas[1].range == (3, 5))
+        XCTAssertTrue(NSEqualRanges(furiganas[1].range, NSMakeRange(3, 2)))
         XCTAssertEqual(furiganas[1].reading, "いっけん")
-        XCTAssertTrue(furiganas[2].range == (6, 7))
+        XCTAssertTrue(NSEqualRanges(furiganas[2].range, NSMakeRange(6, 1)))
         XCTAssertEqual(furiganas[2].reading, "し")
     }
 

--- a/ReedTests/Tokenizer/TokenizerTests.swift
+++ b/ReedTests/Tokenizer/TokenizerTests.swift
@@ -26,7 +26,7 @@ class TokenizerTests: XCTestCase {
         for token in tokens {
             print("=============================")
             print(token.surface)
-            print("range: " + String(token.range.0) + "-" + String(token.range.1))
+            print("range: " + String(token.range.location) + "-" + String(NSMaxRange(token.range)))
             print("------- mecabWordNodes ------")
             dump(token.mecabWordNodes)
             print("----- deinflectionResult ----")


### PR DESCRIPTION
The tokenizer originally represented a range by a `(start, end)` tuple, but I switched to `NSRange` in this p-r. This changed the interface of `Token`s.