### PR TITLE
Shiori/Tokenizer: Fix Tokenizer's inefficiency

### DIFF
--- a/Reed/Dictionary/DictionaryFetcher.swift
+++ b/Reed/Dictionary/DictionaryFetcher.swift
@@ -43,4 +43,22 @@ class DictionaryFetcher {
         return (try? persistentContainer.viewContext.fetch(fetchRequest)) ?? []
     }
     
+    func countEntries(of key: String) -> Int {
+        return isKana(key)
+            ? countReadings(with: key)
+            : countTerms(with: key)
+    }
+    
+    func countReadings(with reading: String) -> Int {
+        let fetchRequest: NSFetchRequest<DictionaryReading> = DictionaryReading.fetchRequest()
+        fetchRequest.predicate = NSPredicate(format: "readingReading == %@", reading)
+        return (try? persistentContainer.viewContext.count(for: fetchRequest)) ?? 0
+    }
+    
+    func countTerms(with term: String) -> Int {
+        let fetchRequest: NSFetchRequest<DictionaryTerm> = DictionaryTerm.fetchRequest()
+        fetchRequest.predicate = NSPredicate(format: "termTerm == %@", term)
+        return (try? persistentContainer.viewContext.count(for: fetchRequest)) ?? 0
+    }
+    
 }

--- a/Reed/Tokenizer/Deinflector.swift
+++ b/Reed/Tokenizer/Deinflector.swift
@@ -14,6 +14,8 @@ struct DeinflectionResult {
 }
 
 class Deinflector {
+    let MAXIMUM_RECURSIVE_DEINFLECTION = 10 // To avoid infinite loop
+    
     lazy var indexedRules: [Int: [String: [Rule]]] = {
         buildIndexedRules(rules: deinflectionRules)
     }()
@@ -44,12 +46,11 @@ class Deinflector {
             conjugationGroupValue: ConjugationGroup.Anything,
             appliedRules: []
         )
-        return recursivelyDeinflect(result: initialResult)
+        return recursivelyDeinflect(result: initialResult, depth: 0)
     }
     
     // Returns an empty list if the text cannot be further deinflected
-    // TODO: Set the maximum number of recursive deinflections to avoid infinite loop
-    func recursivelyDeinflect(result: DeinflectionResult) -> [DeinflectionResult] {
+    func recursivelyDeinflect(result: DeinflectionResult, depth: Int) -> [DeinflectionResult] {
         let text = result.text
         var allResults = [result]
         for sourceLength in indexedRules.keys {
@@ -64,8 +65,10 @@ class Deinflector {
             let results = applyRules(result: result, applicableRules: applicableRules)
             
             // Try to deinflect further
-            for result in results {
-                allResults.append(contentsOf: recursivelyDeinflect(result: result))
+            if depth < MAXIMUM_RECURSIVE_DEINFLECTION {
+                for result in results {
+                    allResults.append(contentsOf: recursivelyDeinflect(result: result, depth: depth + 1))
+                }
             }
         }
         return allResults

--- a/Reed/Tokenizer/Tokenizer.swift
+++ b/Reed/Tokenizer/Tokenizer.swift
@@ -118,6 +118,9 @@ class Tokenizer {
     // Instead, filter plausible definitions when actually displaying them.
     func searchDictionaryDefinitions(nodes: [MecabWordNode], deinflectionResult: DeinflectionResult) -> [DictionaryDefinition] {
         var definitions = [DictionaryDefinition]()
+        if dictionaryFetcher.countEntries(of: deinflectionResult.text) == 0 {
+            return []
+        }
         let entries = dictionaryFetcher.fetchEntries(of: deinflectionResult.text)
         for entry in entries {
             definitions.append(contentsOf: entry.definitions)

--- a/Reed/Tokenizer/Tokenizer.swift
+++ b/Reed/Tokenizer/Tokenizer.swift
@@ -21,7 +21,6 @@ class Tokenizer {
     let dictionaryFetcher: DictionaryFetcher = DictionaryFetcher()
     let mecabWrapper: MecabWrapper = MecabWrapper()
     let deinflector: Deinflector = Deinflector()
-    let partOfSpeechMatcher: PartOfSpeechMatcher = PartOfSpeechMatcher()
     
     func tokenize(_ text: String) -> [Token] {
         let mecabWordNodes = mecabWrapper.tokenize(text)
@@ -115,38 +114,14 @@ class Tokenizer {
         ) : nil
     }
     
+    // This function does not filter dictionary definitions by possible parts of speech.
+    // Instead, filter plausible definitions when actually displaying them.
     func searchDictionaryDefinitions(nodes: [MecabWordNode], deinflectionResult: DeinflectionResult) -> [DictionaryDefinition] {
-        if nodes.endIndex == 1 {
-            var definitionsWithPrimaryPartOfSpeechMatch = [DictionaryDefinition]()
-            var definitionsWithSecondaryPartOfSpeechMatch = [DictionaryDefinition]()
-            let entries = dictionaryFetcher.fetchEntries(of: deinflectionResult.text)
-            for entry in entries {
-                for definition in entry.definitions {
-                    let partsOfSpeech = definition.partsOfSpeech
-                    let matchLevel = partOfSpeechMatcher.match(
-                        features: nodes.first!.features,
-                        jmdictPartsOfSpeech: partsOfSpeech
-                    )
-                    switch matchLevel {
-                    case PartOfSpeechMatchLevel.Primary:
-                        definitionsWithPrimaryPartOfSpeechMatch.append(definition)
-                    case PartOfSpeechMatchLevel.Secondary:
-                        definitionsWithSecondaryPartOfSpeechMatch.append(definition)
-                    case PartOfSpeechMatchLevel.None:
-                        break
-                    }
-                }
-            }
-            return definitionsWithPrimaryPartOfSpeechMatch.isEmpty
-                ? definitionsWithSecondaryPartOfSpeechMatch
-                : definitionsWithPrimaryPartOfSpeechMatch
-        } else {
-            var definitions = [DictionaryDefinition]()
-            let entries = dictionaryFetcher.fetchEntries(of: deinflectionResult.text)
-            for entry in entries {
-                definitions.append(contentsOf: entry.definitions)
-            }
-            return definitions
+        var definitions = [DictionaryDefinition]()
+        let entries = dictionaryFetcher.fetchEntries(of: deinflectionResult.text)
+        for entry in entries {
+            definitions.append(contentsOf: entry.definitions)
         }
+        return definitions
     }
 }

--- a/ReedTests/Dictionary/DictionaryFetcherTests.swift
+++ b/ReedTests/Dictionary/DictionaryFetcherTests.swift
@@ -181,4 +181,75 @@ class DictionaryFetcherTests: XCTestCase {
         res = mockFetcher.fetchEntries(of: "御")
         XCTAssertEqual(res.count, 0)
     }
+    
+    func testCountReadings() {
+        let testData = formatTestData(
+            """
+            [
+                {
+                    "ent_seq": [
+                        "1"
+                    ],
+                    "r_ele": [
+                        {
+                            "reb": [
+                                "あ"
+                            ]
+                        }
+                    ],
+                    "sense": [
+                        {
+                            "gloss": [
+                                "test"
+                            ]
+                        }
+                    ]
+                },
+            ]
+            """
+        )
+        
+        mockParser.parseAndLoad(dictionaryData: testData)
+        XCTAssertEqual(mockFetcher.countEntries(of: "あ"), 1)
+        XCTAssertEqual(mockFetcher.countEntries(of: "い"), 0)
+    }
+    
+    func testCountTerms() {
+        let testData = formatTestData(
+            """
+            [
+                {
+                    "ent_seq": [
+                        "1"
+                    ],
+                    "k_ele": [
+                        {
+                            "keb": [
+                                "阿"
+                            ]
+                        }
+                    ],
+                    "r_ele": [
+                        {
+                            "reb": [
+                                "あ"
+                            ]
+                        }
+                    ],
+                    "sense": [
+                        {
+                            "gloss": [
+                                "test"
+                            ]
+                        }
+                    ]
+                },
+            ]
+            """
+        )
+        
+        mockParser.parseAndLoad(dictionaryData: testData)
+        XCTAssertEqual(mockFetcher.countEntries(of: "阿"), 1)
+        XCTAssertEqual(mockFetcher.countEntries(of: "位"), 0)
+    }
 }


### PR DESCRIPTION
- Disconnect PoS logic from `Tokenizer` https://github.com/Rawgers/Reed/pull/35/commits/5949da976bc6a53f4faa841114e6ea01f15a2767
- Try count before `fetchEntries` https://github.com/Rawgers/Reed/pull/35/commits/c3ab7faa0c5311ac024290d1e79704b2571a052e https://github.com/Rawgers/Reed/pull/35/commits/39198183ed44bbe58d1096c182665f20baf6c9b4
- Fix the infinite loop in `Deinflector` https://github.com/Rawgers/Reed/pull/35/commits/1412c15a2776d6ba28feea318b798ded288c2e73