### PR TITLE
rawger/Reader: Disable scroll on Reader View, fix bottom margin.

### DIFF
--- a/Reed/Components/BottomSheetView.swift
+++ b/Reed/Components/BottomSheetView.swift
@@ -8,25 +8,25 @@
 
 import SwiftUI
 
-fileprivate enum Constants {
-    static let radius: CGFloat = 16
-    static let indicatorHeight: CGFloat = 2
-    static let indicatorWidth: CGFloat = 32
-    static let snapRatio: CGFloat = 0.25
+enum BottomSheetConstants {
     static let minHeight: CGFloat = 120
     static let maxHeight: CGFloat = UIScreen.main.bounds.height * 0.4
+    fileprivate static let radius: CGFloat = 16
+    fileprivate static let indicatorHeight: CGFloat = 2
+    fileprivate static let indicatorWidth: CGFloat = 32
+    fileprivate static let snapRatio: CGFloat = 0.25
 }
 
 struct BottomSheetView<Content: View>: View {
     @Binding var isOpen: Bool
     
-    let maxHeight: CGFloat
     let minHeight: CGFloat
+    let maxHeight: CGFloat
     let content: Content
     
     init(isOpen: Binding<Bool>, @ViewBuilder content: () -> Content) {
-        self.minHeight = Constants.minHeight
-        self.maxHeight = Constants.maxHeight
+        self.minHeight = BottomSheetConstants.minHeight
+        self.maxHeight = BottomSheetConstants.maxHeight
         self.content = content()
         self._isOpen = isOpen
     }
@@ -36,11 +36,11 @@ struct BottomSheetView<Content: View>: View {
     }
     
     private var indicator: some View {
-        RoundedRectangle(cornerRadius: Constants.radius)
+        RoundedRectangle(cornerRadius: BottomSheetConstants.radius)
             .fill(Color(.systemGray4))
             .frame(
-                width: Constants.indicatorWidth,
-                height: Constants.indicatorHeight
+                width: BottomSheetConstants.indicatorWidth,
+                height: BottomSheetConstants.indicatorHeight
             )
     }
     
@@ -54,8 +54,12 @@ struct BottomSheetView<Content: View>: View {
                 self.content
             }
             .frame(width: geometry.size.width, height: self.maxHeight, alignment: .top)
-            .background(colorScheme == .dark ? Color(.secondarySystemBackground) : Color.white)
-            .cornerRadius(Constants.radius)
+            .background(
+                colorScheme == .dark
+                    ? Color(.secondarySystemBackground)
+                    : Color.white
+            )
+            .cornerRadius(BottomSheetConstants.radius)
             .shadow(radius: 4)
             .frame(height: geometry.size.height, alignment: .bottom)
             .offset(y: max(self.offset + self.translation, 0))
@@ -64,7 +68,7 @@ struct BottomSheetView<Content: View>: View {
                 DragGesture().updating(self.$translation) { value, state, _ in
                     state = value.translation.height
                 }.onEnded { value in
-                    let snapDistance = self.maxHeight * Constants.snapRatio
+                    let snapDistance = self.maxHeight * BottomSheetConstants.snapRatio
                     guard abs(value.translation.height) > snapDistance else {
                         return
                     }

--- a/Reed/Components/DefinableTextView.swift
+++ b/Reed/Components/DefinableTextView.swift
@@ -36,15 +36,22 @@ struct DefinableTextView: UIViewRepresentable {
     @Binding var text: String
     var tokens: [Token]
     let definerResultHandler: ([DefinitionDetails]) -> Void
+    let width: CGFloat
+    let height: CGFloat
     
-    func makeUIView(context: UIViewRepresentableContext<DefinableTextView>) -> UITextView {
-        let textView = UITextView()
+    func makeUIView(
+        context: UIViewRepresentableContext<DefinableTextView>
+    ) -> UITextView {
+        let textView = UITextView(frame: CGRect.zero)
+        
+        textView.text = text
+        textView.font = .systemFont(ofSize: 20)
+        textView.textAlignment = .justified
+        
         textView.isEditable = false
         textView.isSelectable = false
-        textView.text = text
-        textView.contentSize = CGSize(width: UIScreen.main.bounds.width * 0.9, height: UIScreen.main.bounds.height * 0.6)
-        textView.font = .systemFont(ofSize: 17)
-        textView.textAlignment = .justified
+        textView.sizeToFit()
+        
         textView.addGestureRecognizer(
             UITapGestureRecognizer(
                 target: context.coordinator,
@@ -54,7 +61,10 @@ struct DefinableTextView: UIViewRepresentable {
         return textView
     }
     
-    func updateUIView(_ textView: UITextView, context: UIViewRepresentableContext<DefinableTextView>) {
+    func updateUIView(
+        _ textView: UITextView,
+        context: UIViewRepresentableContext<DefinableTextView>
+    ) {
         textView.text = text
     }
     

--- a/Reed/Reader/viewmodels/ReaderViewModel.swift
+++ b/Reed/Reader/viewmodels/ReaderViewModel.swift
@@ -28,16 +28,25 @@ class ReaderViewModel: ObservableObject {
     let model: ReaderModel
     var historyEntry: HistoryEntry?
     var section: SectionContent?
-    var content: String = ""
     @Published var items = [String]()
     
     @Published var pages: [Page] = []
     @Published var curPage: Int = 0
     var lastPage: Int = 0
     
+    let pagerWidth: CGFloat = {
+        let edgeInsets = EdgeInsets()
+        return UIScreen.main.bounds.width - 32
+    }()
+    let pagerHeight: CGFloat = {
+        let definerOffset = BottomSheetConstants.maxHeight - BottomSheetConstants.minHeight
+        return UIScreen.main.bounds.height - definerOffset - 32
+    }()
+    
     init(persistentContainer: NSPersistentContainer, ncode: String) {
         self.persistentContainer = persistentContainer
         self.model = ReaderModel(ncode: ncode)
+        
         HistoryEntry.fetch(
             persistentContainer: persistentContainer,
             ncode: ncode
@@ -86,11 +95,10 @@ class ReaderViewModel: ObservableObject {
     }
     
     func calcPages(content: String) -> [Page] {
-        let userWidth = UIScreen.main.bounds.width * 0.95
-        let userHeight = UIScreen.main.bounds.height * 0.5
-        let rect = CGRect(x: 0, y: 0, width: userWidth, height: userHeight)
+        let rect = CGRect(x: 0, y: 0, width: pagerWidth, height: pagerHeight)
         let tempTextView = UITextView(frame: rect)
-        tempTextView.font = .systemFont(ofSize: 17)
+        tempTextView.font = .systemFont(ofSize: 20)
+        tempTextView.textAlignment = .justified
         
         var remainingContent = content
         var pages = [Page]()

--- a/Reed/Reader/views/ReaderView.swift
+++ b/Reed/Reader/views/ReaderView.swift
@@ -30,7 +30,9 @@ struct ReaderView: View {
                         DefinableTextView(
                             text: .constant(page.content),
                             tokens: page.tokens,
-                            definerResultHandler: definerResultHandler
+                            definerResultHandler: definerResultHandler,
+                            width: viewModel.pagerWidth,
+                            height: viewModel.pagerHeight
                         )
                     }
                 )
@@ -38,15 +40,15 @@ struct ReaderView: View {
                     self.viewModel.handlePageFlip(isInit: page == -1)
                 }
                 .alignment(.start)
-                .preferredItemSize(CGSize(
-                    width: UIScreen.main.bounds.width,
-                    height: UIScreen.main.bounds.height * 0.65
-                ))
+                
                 Text("\(viewModel.curPage + 1) of \(viewModel.pages.endIndex)")
-                Spacer()
-                    .frame(height: UIScreen.main.bounds.height * 0.15)
+                
+                Rectangle()
+                    .frame(height: BottomSheetConstants.minHeight)
+                    .opacity(0)
             }
             .padding(.horizontal)
+            .ignoresSafeArea(edges: .bottom)
             
             DefinerView(entries: $entries)
         }


### PR DESCRIPTION
This commit addresses and issue where certain pages will become scrollable when the text pushes against the bottom edge of the DefinableTextView. We disable this behavior by having the DefinableTextView take up as much available space as possible, and then constraining its bottom with a placeholder rectangle at the location of the minimized Definer.

Full screen of text, no scroll.
![Screen Shot 2021-01-07 at 4 00 36 PM](https://user-images.githubusercontent.com/29548429/103958291-7eda8780-5101-11eb-990a-36476a7ae115.png)

It should also be noted that depending on the font size, there will be varying degrees of "padding" between the last line of text and the page count. That being said, no text is lost on the page boundaries regardless of text size.