### PR TITLE
hugo/{DefinableTextView, ReaderViewModel, ReaderView, ReaderViewModelTests}:

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,12 +1,12 @@
 PODS:
   - GzipSwift (5.1.1)
-  - Introspect (0.1.1)
+  - Introspect (0.1.2)
   - mecab-ko (0.4.0)
   - mecab-naist-jdic-utf-8 (0.1.3)
   - SwiftSoup (2.3.2)
-  - SwiftUIPager (1.13.0)
+  - SwiftUIPager (1.14.1)
   - SwiftyJSON (5.0.0)
-  - SwiftyNarou (1.1.11):
+  - SwiftyNarou (1.1.12):
     - GzipSwift
     - SwiftSoup
     - SwiftyJSON
@@ -33,13 +33,13 @@ SPEC REPOS:
 
 SPEC CHECKSUMS:
   GzipSwift: 893f3e48e597a1a4f62fafcb6514220fcf8287fa
-  Introspect: 50c17d6b1f091f4cfd678ea8a4157ac071808fe3
+  Introspect: 85a29d2c5ee4d3d15469ad0b75fd8839f3e72674
   mecab-ko: 45633c9b839e8e1f025cd1895ca943de5b3e0efa
   mecab-naist-jdic-utf-8: 0df05453d30e5774bf28f019eb45507fc8a4f740
   SwiftSoup: f97bc4e988c7729d6457f9642f974c617a6e2510
-  SwiftUIPager: 022f9043921d75053c4a8f3eea0b298b6846ee3e
+  SwiftUIPager: 8ecefbab2f6c0ec95a780d6e4dc5fc8d7be68402
   SwiftyJSON: 36413e04c44ee145039d332b4f4e2d3e8d6c4db7
-  SwiftyNarou: 216efd79d945f2a7f0d98b843ccf1f35680ffe94
+  SwiftyNarou: bf6894c4bd35978324af45222b070187e430ad17
 
 PODFILE CHECKSUM: 142f4fbbdd16e1fa598e549f8752e3846261b915
 

--- a/Reed.xcodeproj/xcshareddata/xcschemes/Reed.xcscheme
+++ b/Reed.xcodeproj/xcshareddata/xcschemes/Reed.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1220"
+   LastUpgradeVersion = "1230"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Reed/Components/DefinableTextView.swift
+++ b/Reed/Components/DefinableTextView.swift
@@ -52,12 +52,12 @@ struct DefinableTextView: UIViewRepresentable {
         textView.isSelectable = false
         textView.sizeToFit()
         
-        textView.addGestureRecognizer(
-            UITapGestureRecognizer(
-                target: context.coordinator,
-                action: #selector(Coordinator.wordTapped(gesture:))
-            )
+        let singleTapGesture = UITapGestureRecognizer(
+            target: context.coordinator,
+            action: #selector(Coordinator.wordTapped(gesture:))
         )
+        singleTapGesture.numberOfTapsRequired = 1
+        textView.addGestureRecognizer(singleTapGesture)
         return textView
     }
     
@@ -90,12 +90,15 @@ struct DefinableTextView: UIViewRepresentable {
             let position = CGPoint(x: location.x + textView.font!.pointSize / 2, y: location.y)
             let tapPosition = textView.closestPosition(to: position)
             let tappedIndex = textView.offset(from: textView.beginningOfDocument, to: tapPosition!) - 1
-            let token = tokens[getToken(l: 0, r: tokens.count - 1, x: tappedIndex)]
-            tappedRange = token.range
-                        highlightSelection(textView: textView)
-                        defineSelection(from: token.surface)
-                    }
-
+            let index = getToken(l: 0, r: tokens.count - 1, x: tappedIndex)
+            if index > -1 {
+                let token = tokens[index]
+                tappedRange = token.range
+                highlightSelection(textView: textView)
+                defineSelection(from: token.surface)
+            }
+        }
+        
         func getToken(l: Int, r: Int, x: Int) -> Int {
             if r >= l {
                 let mid = l + (r - l) / 2

--- a/Reed/Reader/views/ReaderView.swift
+++ b/Reed/Reader/views/ReaderView.swift
@@ -27,29 +27,36 @@ struct ReaderView: View {
                     data: viewModel.pages,
                     id: \.self,
                     content: { page in
-                        DefinableTextView(
-                            text: .constant(page.content),
-                            tokens: page.tokens,
-                            definerResultHandler: definerResultHandler,
-                            width: viewModel.pagerWidth,
-                            height: viewModel.pagerHeight
-                        )
+                        if viewModel.curPage == -1
+                            || (viewModel.section?.nextNcode != nil && viewModel.curPage == viewModel.pages.endIndex - 1)
+                            || (viewModel.section?.prevNcode != nil && viewModel.curPage == 0) {
+                            ProgressView()
+                        } else {
+                            DefinableTextView(
+                                text: .constant(page.content),
+                                tokens: page.tokens,
+                                definerResultHandler: definerResultHandler,
+                                width: viewModel.pagerWidth,
+                                height: viewModel.pagerHeight
+                            )
+                        }
                     }
                 )
+                .allowsDragging((viewModel.section?.prevNcode == nil || viewModel.curPage != 0)
+                                    && (viewModel.section?.nextNcode == nil || viewModel.curPage != viewModel.pages.endIndex - 1))
                 .onPageChanged { page in
                     self.viewModel.handlePageFlip(isInit: page == -1)
                 }
                 .alignment(.start)
                 
-                Text("\(viewModel.curPage + 1) of \(viewModel.pages.endIndex)")
+                Text(viewModel.getPageNumberDisplay())
                 
                 Rectangle()
                     .frame(height: BottomSheetConstants.minHeight)
                     .opacity(0)
             }
             .padding(.horizontal)
-            .ignoresSafeArea(edges: .bottom)
-            
+        
             DefinerView(entries: $entries)
         }
         .navigationBarHidden(true)


### PR DESCRIPTION
1. Fixed mishandling of binary search returning -1 in DefinableTextView, which previously has caused the app to crash due to retrieving a token that does not exist. 
2. Modified section loading logic ReaderView and ReaderViewModel to fix a bug where an incomplete scroll at the start and end pages will cause the next section to load. This is done by adding two loading pages to each section so that when the user swipes onto the loading page, the next or previous section will be loaded. The first section does not have a front loading page and the last section does not have a loading page.
3. Modified ReaderViewModelTests to test the new implementations of the loading pages

![Simulator Screen Shot - iPhone 12 Pro Max - 2021-01-07 at 17 00 18](https://user-images.githubusercontent.com/42554019/103962562-180e9b80-510c-11eb-84de-76fb01d00027.png)
