### PR TITLE
hugo: {DefinableTextView, DiscoveryView, LibraryView, NovelDetailsView, ReaderView}: Double tap to show/hide navBar:

### DIFF
--- a/Reed/Components/DefinableTextView.swift
+++ b/Reed/Components/DefinableTextView.swift
@@ -36,6 +36,7 @@ struct DefinableTextView: UIViewRepresentable {
     @Binding var text: String
     var tokens: [Token]
     let definerResultHandler: ([DefinitionDetails]) -> Void
+    let hideNavHandler: () -> Void
     let width: CGFloat
     let height: CGFloat
     
@@ -58,6 +59,14 @@ struct DefinableTextView: UIViewRepresentable {
         )
         singleTapGesture.numberOfTapsRequired = 1
         textView.addGestureRecognizer(singleTapGesture)
+        
+        let doubleTapGesture = UITapGestureRecognizer(
+            target: context.coordinator,
+            action: #selector(Coordinator.doubleTapped)
+        )
+        doubleTapGesture.numberOfTapsRequired = 2
+        textView.addGestureRecognizer(doubleTapGesture)
+        singleTapGesture.require(toFail: doubleTapGesture)
         return textView
     }
     
@@ -69,7 +78,7 @@ struct DefinableTextView: UIViewRepresentable {
     }
     
     func makeCoordinator() -> DefinableTextView.Coordinator {
-        return Coordinator(tokens: tokens, definerResultHandler: definerResultHandler)
+        return Coordinator(tokens: tokens, definerResultHandler: definerResultHandler, hideNavHandler: hideNavHandler)
     }
     
     class Coordinator: NSObject {
@@ -78,10 +87,20 @@ struct DefinableTextView: UIViewRepresentable {
         let dictionaryFetcher = DictionaryFetcher()
         let tokens: [Token]
         let definerResultHandler: ([DefinitionDetails]) -> Void
+        let hideNavHandler: () -> Void
         
-        init(tokens: [Token], definerResultHandler: @escaping ([DefinitionDetails]) -> Void) {
+        init(
+            tokens: [Token],
+            definerResultHandler: @escaping ([DefinitionDetails]) -> Void,
+            hideNavHandler: @escaping () -> Void
+        ) {
             self.tokens = tokens
             self.definerResultHandler = definerResultHandler
+            self.hideNavHandler = hideNavHandler
+        }
+        
+        @objc func doubleTapped() {
+            hideNavHandler()
         }
         
         @objc func wordTapped(gesture: UITapGestureRecognizer) {

--- a/Reed/DiscoverTab/DiscoverView.swift
+++ b/Reed/DiscoverTab/DiscoverView.swift
@@ -11,7 +11,8 @@ import SwiftUI
 struct DiscoverView: View {
     @ObservedObject var searchViewModel = DiscoverSearchViewModel()
     @ObservedObject var viewModel = DiscoverViewModel()
-    
+    @State private var tabBar: UITabBar?
+
     var body: some View {
         NavigationView {
             ScrollView {
@@ -56,6 +57,12 @@ struct DiscoverView: View {
                 from: searchViewModel.searchBar,
                 hidesWhenScrolling: false
             )
+            .introspectTabBarController { tabBarController in
+                self.tabBar = tabBarController.tabBar
+            }
+            .onAppear {
+                tabBar?.isHidden = false
+            }
         }
         .navigationViewStyle(StackNavigationViewStyle())
     }

--- a/Reed/LibraryTab/views/LibraryView.swift
+++ b/Reed/LibraryTab/views/LibraryView.swift
@@ -10,7 +10,8 @@ import SwiftUI
 
 struct LibraryView: View {
     @ObservedObject var viewModel: LibraryViewModel = LibraryViewModel()
-    
+    @State private var tabBar: UITabBar?
+
     var body: some View {
         NavigationView {
             List {
@@ -18,9 +19,16 @@ struct LibraryView: View {
                     LibraryEntryView(entryData: $0)
                 }
             }
-            .onAppear { viewModel.fetchEntries() }
+            .introspectTabBarController { tabBarController in
+                self.tabBar = tabBarController.tabBar
+            }
+            .onAppear {
+                viewModel.fetchEntries()
+                self.tabBar?.isHidden = false
+            }
             .navigationBarTitle("Library")
         }
+        .navigationViewStyle(StackNavigationViewStyle())
     }
 }
 

--- a/Reed/NovelDetails/views/NovelDetailsView.swift
+++ b/Reed/NovelDetails/views/NovelDetailsView.swift
@@ -14,7 +14,6 @@ struct NovelDetailsView: View {
     @State private var topExpanded: Bool = true
     @State private var entries: [DefinitionDetails] = []
     @State private var isPushedToReader: Bool = false
-    @State private var tabBar: UITabBar?
     
     init(ncode: String) {
         viewModel = NovelDetailsViewModel(ncode: ncode)
@@ -95,10 +94,8 @@ struct NovelDetailsView: View {
             }
             .padding(.horizontal)
             .introspectTabBarController { tabBarController in
-                tabBar = tabBarController.tabBar
-                self.tabBar?.isHidden = true
+                tabBarController.tabBar.isHidden = true
             }
-            .onDisappear { self.tabBar?.isHidden = false }
 
             DefinerView(entries: self.$entries)
         }

--- a/Reed/Reader/views/ReaderView.swift
+++ b/Reed/Reader/views/ReaderView.swift
@@ -13,7 +13,7 @@ import SwiftUIPager
 struct ReaderView: View {
     @ObservedObject var viewModel: ReaderViewModel
     @State private var entries = [DefinitionDetails]()
-    @State private var tabBar: UITabBar?
+    @State private var navBar: UINavigationBar?
 
     init(ncode: String) {
         self.viewModel = ReaderViewModel(ncode: ncode)
@@ -36,6 +36,7 @@ struct ReaderView: View {
                                 text: .constant(page.content),
                                 tokens: page.tokens,
                                 definerResultHandler: definerResultHandler,
+                                hideNavHandler: hideNavHandler,
                                 width: viewModel.pagerWidth,
                                 height: viewModel.pagerHeight
                             )
@@ -60,16 +61,26 @@ struct ReaderView: View {
         
             DefinerView(entries: $entries)
         }
-        .navigationBarHidden(true)
-        .introspectTabBarController { tabBarController in
-            tabBar = tabBarController.tabBar
-            self.tabBar?.isHidden = true
+        .navigationBarTitle("", displayMode: .inline)
+        .introspectNavigationController { navigationController in
+            self.navBar = navigationController.navigationBar
+            self.navBar?.isHidden = true
+            self.navBar?.backgroundColor = .systemBackground
         }
-        .onDisappear { self.tabBar?.isHidden = false }
+        .introspectTabBarController { tabBarController in
+            tabBarController.tabBar.isHidden = true
+        }
+        .onTapGesture(count: 2) {
+            hideNavHandler()
+        }
     }
     
     func definerResultHandler(newEntries: [DefinitionDetails]) {
         self.entries = newEntries
+    }
+    
+    func hideNavHandler() {
+        navBar?.isHidden = !(navBar?.isHidden ?? true)
     }
 }
 


### PR DESCRIPTION
1. Passed a function handler into the definable text view to handle double tapps similar to the definer function handler.
2. Double taps call a function that show/hide the navBar in readerView accessed by introspect.
3. Instead of using introspect in the reader and novel details to change tabBar.isHidden, now this is done in discovery and library. This solves the issue of the tabBar not disappearing until the reader or novel details is fully loaded.

light:
<img width="50%" alt="Screen Shot 2021-01-10 at 1 57 02 AM" src="https://user-images.githubusercontent.com/42554019/104119858-59a76e00-52e7-11eb-8f0a-4b64e3b06c23.png">

dark:
<img width="50%" alt="Screen Shot 2021-01-10 at 4 42 34 PM" src="https://user-images.githubusercontent.com/42554019/104139843-eba08c80-5362-11eb-9403-0efc822bc4f4.png">
