### PR TITLE
rawger/Reader: Change SectionContent to SectionData.

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -4,7 +4,7 @@ target 'Reed' do
   pod 'GzipSwift'
   pod 'Introspect'
   pod 'SwiftyJSON'
-  pod 'SwiftUIPager'
+  pod 'SwiftUIPager', '1.14.1'
   pod 'SwiftyNarou'
   pod 'mecab-ko'
   pod 'mecab-naist-jdic-utf-8'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -6,7 +6,7 @@ PODS:
   - SwiftSoup (2.3.2)
   - SwiftUIPager (1.14.1)
   - SwiftyJSON (5.0.0)
-  - SwiftyNarou (1.1.12):
+  - SwiftyNarou (1.1.13):
     - GzipSwift
     - SwiftSoup
     - SwiftyJSON
@@ -16,7 +16,7 @@ DEPENDENCIES:
   - Introspect
   - mecab-ko
   - mecab-naist-jdic-utf-8
-  - SwiftUIPager
+  - SwiftUIPager (= 1.14.1)
   - SwiftyJSON
   - SwiftyNarou
 
@@ -39,8 +39,8 @@ SPEC CHECKSUMS:
   SwiftSoup: f97bc4e988c7729d6457f9642f974c617a6e2510
   SwiftUIPager: 8ecefbab2f6c0ec95a780d6e4dc5fc8d7be68402
   SwiftyJSON: 36413e04c44ee145039d332b4f4e2d3e8d6c4db7
-  SwiftyNarou: bf6894c4bd35978324af45222b070187e430ad17
+  SwiftyNarou: 2288ba057c210f2b50309bf0e7f7731d3c5ad2f5
 
-PODFILE CHECKSUM: 142f4fbbdd16e1fa598e549f8752e3846261b915
+PODFILE CHECKSUM: 86ebafd8c36a1fae1eb36e54e172bded243aa6c0
 
-COCOAPODS: 1.10.0
+COCOAPODS: 1.10.1

--- a/Reed.xcodeproj/xcshareddata/xcschemes/Reed.xcscheme
+++ b/Reed.xcodeproj/xcshareddata/xcschemes/Reed.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1230"
+   LastUpgradeVersion = "1220"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Reed/Reader/models/ReaderModel.swift
+++ b/Reed/Reader/models/ReaderModel.swift
@@ -15,11 +15,11 @@ class ReaderModel {
         self.ncode = ncode
     }
     
-    func fetchSectionContent(
+    func fetchSectionData(
         sectionNcode: String,
-        completion: @escaping (SectionContent?) -> Void
+        completion: @escaping (SectionData?) -> Void
     ) {
-        Narou.fetchSectionContent(ncode: sectionNcode) { data, error in
+        Narou.fetchSectionData(ncode: sectionNcode) { data, error in
             if error != nil {
                 print("Failed to retrieve section content due to: \(error.debugDescription)")
                 completion(nil)

--- a/Reed/Reader/viewmodels/ReaderViewModel.swift
+++ b/Reed/Reader/viewmodels/ReaderViewModel.swift
@@ -27,7 +27,7 @@ class ReaderViewModel: ObservableObject {
     let persistentContainer: NSPersistentContainer
     let model: ReaderModel
     var historyEntry: HistoryEntry?
-    var section: SectionContent?
+    var section: SectionData?
     @Published var items = [String]()
     @Published var pages: [Page] = []
     @Published var curPage: Int = -1
@@ -83,7 +83,7 @@ class ReaderViewModel: ObservableObject {
         guard let historyEntry = self.historyEntry else {
             fatalError("Unable to retrieve HistoryEntry.")
         }
-        self.model.fetchSectionContent(sectionNcode: historyEntry.sectionNcode) { section in
+        self.model.fetchSectionData(sectionNcode: historyEntry.sectionNcode) { section in
             self.section = section
             self.pages = self.calcPages(content: section?.content ?? "")
             completion()

--- a/ReedTests/Reader/ReaderViewModelTests.swift
+++ b/ReedTests/Reader/ReaderViewModelTests.swift
@@ -8,8 +8,10 @@
 
 import CoreData
 import XCTest
-@testable import Reed
+
 import SwiftyNarou
+
+@testable import Reed
 
 class ReaderViewModelTests: XCTestCase {
     lazy var managedObjectModel: NSManagedObjectModel = {
@@ -88,8 +90,17 @@ class ReaderViewModelTests: XCTestCase {
         XCTAssertNil(mockViewModel.section?.prevNcode)
         XCTAssertEqual(mockViewModel.historyEntry?.lastReadSection.id, 1)
         
-        // TODO: nothing should happen if we try to flip to a next section that doesn't exist
-        mockViewModel.section = SectionContent(sectionTitle: "test last section", chapterTitle: "last chapter", novelTitle: "last novel", writer: "last writer", content: "last content", format: [NSRange: String](), prevNcode: nil, nextNcode: nil, progress: "last progress")
+        mockViewModel.section = SectionData(
+            sectionTitle: "test last section",
+            chapterTitle: "last chapter",
+            novelTitle: "last novel",
+            writer: "last writer",
+            content: "last content",
+            format: [NSRange: String](),
+            prevNcode: nil,
+            nextNcode: nil,
+            progress: "last progress"
+        )
         mockViewModel.pages  = mockViewModel.calcPages(content: "last writer")
         XCTAssertTrue(mockViewModel.pages.endIndex == 1)
     }


### PR DESCRIPTION
Refactors the SectionContent struct to use SectionData, reflecting changes in SwiftyNarou. This change clears up the confusion where SectionContent had a content field, in addition to other metadata.

This commit also freezes the SwiftUIPager to version 1.14.1 because version 2.0 introduces breaking changes.