### PR TITLE
Rawger/{Reader, SectionNavigation}: Introducing Section Navigation

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -6,7 +6,7 @@ PODS:
   - SwiftSoup (2.3.2)
   - SwiftUIPager (1.14.1)
   - SwiftyJSON (5.0.0)
-  - SwiftyNarou (1.1.13):
+  - SwiftyNarou (1.1.14):
     - GzipSwift
     - SwiftSoup
     - SwiftyJSON
@@ -39,7 +39,7 @@ SPEC CHECKSUMS:
   SwiftSoup: f97bc4e988c7729d6457f9642f974c617a6e2510
   SwiftUIPager: 8ecefbab2f6c0ec95a780d6e4dc5fc8d7be68402
   SwiftyJSON: 36413e04c44ee145039d332b4f4e2d3e8d6c4db7
-  SwiftyNarou: 2288ba057c210f2b50309bf0e7f7731d3c5ad2f5
+  SwiftyNarou: 3485ee3aee9619eba72e135a68c5e718c874540d
 
 PODFILE CHECKSUM: 86ebafd8c36a1fae1eb36e54e172bded243aa6c0
 

--- a/Reed.xcodeproj/project.pbxproj
+++ b/Reed.xcodeproj/project.pbxproj
@@ -48,6 +48,8 @@
 		B8462309250AF5A3002358A0 /* DictionaryParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8462308250AF5A3002358A0 /* DictionaryParser.swift */; };
 		B846482F2526CB5000D5A76D /* DictionaryFetcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B846482E2526CB5000D5A76D /* DictionaryFetcherTests.swift */; };
 		B8539EE52519755A000FF025 /* DictionaryStorageManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8539EE42519755A000FF025 /* DictionaryStorageManagerTests.swift */; };
+		B85CFB9225B39E8D0022440B /* SectionNavigationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B85CFB9125B39E8D0022440B /* SectionNavigationView.swift */; };
+		B85CFB9A25B39EF80022440B /* SectionNavigationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B85CFB9925B39EF80022440B /* SectionNavigationViewModel.swift */; };
 		B860B7122518207900F48FBE /* JMdict_e.json.gz in Resources */ = {isa = PBXBuildFile; fileRef = B860B7112518207800F48FBE /* JMdict_e.json.gz */; };
 		B86550CD255A08D800E4786F /* HistoryEntry+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = B86550CA255A08D800E4786F /* HistoryEntry+CoreDataProperties.swift */; };
 		B86550CE255A08D800E4786F /* HistorySection+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = B86550CB255A08D800E4786F /* HistorySection+CoreDataClass.swift */; };
@@ -71,6 +73,8 @@
 		B89CD698250993F800D7D8ED /* DefinerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B89CD697250993F800D7D8ED /* DefinerView.swift */; };
 		B89CD69A2509944200D7D8ED /* MockCards.swift in Sources */ = {isa = PBXBuildFile; fileRef = B89CD6992509944200D7D8ED /* MockCards.swift */; };
 		B8A5E50E2527BACE003BCF07 /* UtilsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8A5E50D2527BACE003BCF07 /* UtilsTests.swift */; };
+		B8A704F225B8212200E605CC /* NavigationBackChevron.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8A704F125B8212200E605CC /* NavigationBackChevron.swift */; };
+		B8A7051225B8380000E605CC /* SectionNavigationModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8A7051125B8380000E605CC /* SectionNavigationModel.swift */; };
 		B8A78F072542F26700577974 /* DiscoverList.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8A78F062542F26700577974 /* DiscoverList.swift */; };
 		B8A78F0C2542F27200577974 /* DiscoverListItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8A78F0B2542F27200577974 /* DiscoverListItem.swift */; };
 		B8ADEAB52570E0CC007C3D28 /* View+readSize.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8ADEAB42570E0CC007C3D28 /* View+readSize.swift */; };
@@ -166,6 +170,8 @@
 		B8462308250AF5A3002358A0 /* DictionaryParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictionaryParser.swift; sourceTree = "<group>"; };
 		B846482E2526CB5000D5A76D /* DictionaryFetcherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictionaryFetcherTests.swift; sourceTree = "<group>"; };
 		B8539EE42519755A000FF025 /* DictionaryStorageManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictionaryStorageManagerTests.swift; sourceTree = "<group>"; };
+		B85CFB9125B39E8D0022440B /* SectionNavigationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SectionNavigationView.swift; sourceTree = "<group>"; };
+		B85CFB9925B39EF80022440B /* SectionNavigationViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SectionNavigationViewModel.swift; sourceTree = "<group>"; };
 		B860B7112518207800F48FBE /* JMdict_e.json.gz */ = {isa = PBXFileReference; lastKnownFileType = archive.gzip; path = JMdict_e.json.gz; sourceTree = "<group>"; };
 		B86550CA255A08D800E4786F /* HistoryEntry+CoreDataProperties.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "HistoryEntry+CoreDataProperties.swift"; sourceTree = "<group>"; };
 		B86550CB255A08D800E4786F /* HistorySection+CoreDataClass.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "HistorySection+CoreDataClass.swift"; sourceTree = "<group>"; };
@@ -188,6 +194,8 @@
 		B89CD697250993F800D7D8ED /* DefinerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefinerView.swift; sourceTree = "<group>"; };
 		B89CD6992509944200D7D8ED /* MockCards.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockCards.swift; sourceTree = "<group>"; };
 		B8A5E50D2527BACE003BCF07 /* UtilsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UtilsTests.swift; sourceTree = "<group>"; };
+		B8A704F125B8212200E605CC /* NavigationBackChevron.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationBackChevron.swift; sourceTree = "<group>"; };
+		B8A7051125B8380000E605CC /* SectionNavigationModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SectionNavigationModel.swift; sourceTree = "<group>"; };
 		B8A78F062542F26700577974 /* DiscoverList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscoverList.swift; sourceTree = "<group>"; };
 		B8A78F0B2542F27200577974 /* DiscoverListItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscoverListItem.swift; sourceTree = "<group>"; };
 		B8ADEAB42570E0CC007C3D28 /* View+readSize.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+readSize.swift"; sourceTree = "<group>"; };
@@ -342,6 +350,7 @@
 				B82AF5FC2548031F00FAB2A8 /* ViewControllerResolver.swift */,
 				B82AF5DC2548015B00FAB2A8 /* View+UIKitComponents.swift */,
 				B8ADEAB92570E205007C3D28 /* FlexView.swift */,
+				B8A704F125B8212200E605CC /* NavigationBackChevron.swift */,
 			);
 			path = Components;
 			sourceTree = "<group>";
@@ -422,6 +431,16 @@
 				B80E0E6F25497EBA009B0EE8 /* DiscoverSearchResultsViewModel.swift */,
 			);
 			path = viewmodels;
+			sourceTree = "<group>";
+		};
+		B85CFB9025B38AC80022440B /* SectionNavigation */ = {
+			isa = PBXGroup;
+			children = (
+				B85CFB9125B39E8D0022440B /* SectionNavigationView.swift */,
+				B85CFB9925B39EF80022440B /* SectionNavigationViewModel.swift */,
+				B8A7051125B8380000E605CC /* SectionNavigationModel.swift */,
+			);
+			path = SectionNavigation;
 			sourceTree = "<group>";
 		};
 		B8667F112509CA5D001EABD4 /* views */ = {
@@ -563,8 +582,8 @@
 				B8D456AA2508D1A2000F9E5F /* Info.plist */,
 				B8D456CC2508D2E3000F9E5F /* Main */,
 				B82AF5D92548015B00FAB2A8 /* Components */,
-				B8977921256626D400DF1B79 /* Tokenizer */,
 				B8981109250F803F0059F71F /* Extensions */,
+				B8977921256626D400DF1B79 /* Tokenizer */,
 				B8462307250AF4E4002358A0 /* Dictionary */,
 				B880D135251810C90097AF8D /* SplashScreen */,
 				B8D456CF2508D8D7000F9E5F /* CardsTab */,
@@ -572,6 +591,7 @@
 				B8D456CD2508D349000F9E5F /* LibraryTab */,
 				B8FA93AD254BAD4800AE362C /* NovelDetails */,
 				B8D456CE2508D8D3000F9E5F /* Reader */,
+				B85CFB9025B38AC80022440B /* SectionNavigation */,
 				6D86DA41255DB9D100806E12 /* Definer */,
 				B8D456D12508D8E4000F9E5F /* SettingsTab */,
 				B8D456A42508D1A2000F9E5F /* Preview Content */,
@@ -941,6 +961,7 @@
 				B80F45BC25411271004F8A22 /* DiscoverListViewModel.swift in Sources */,
 				B880D139251810F20097AF8D /* SplashViewModel.swift in Sources */,
 				6D12985A256E1BB500E873F4 /* DefinerTab.swift in Sources */,
+				B85CFB9A25B39EF80022440B /* SectionNavigationViewModel.swift in Sources */,
 				B8FA93B1254BAEEC00AE362C /* NovelDetailsViewModel.swift in Sources */,
 				B86550CD255A08D800E4786F /* HistoryEntry+CoreDataProperties.swift in Sources */,
 				B8C88D7C256F9FC0006CD768 /* DictionaryUtils.swift in Sources */,
@@ -952,12 +973,14 @@
 				B8D4569F2508D1A2000F9E5F /* Reed.xcdatamodeld in Sources */,
 				6D1298EE257239E400E873F4 /* HistorySection+CoreDataProperties.swift in Sources */,
 				B8B8F9912526C10400D6DF8B /* DictionaryFetcher.swift in Sources */,
+				B85CFB9225B39E8D0022440B /* SectionNavigationView.swift in Sources */,
 				B86550CE255A08D800E4786F /* HistorySection+CoreDataClass.swift in Sources */,
 				B89CD68625098C0100D7D8ED /* DiscoverView.swift in Sources */,
 				B8667F102509C745001EABD4 /* AppView.swift in Sources */,
 				B82E94A42566332D004A6F85 /* MecabWordNode.swift in Sources */,
 				B8F5C218250EDEEB000810F8 /* DictionaryTerm+CoreDataProperties.swift in Sources */,
 				B8667F132509CA68001EABD4 /* SettingsView.swift in Sources */,
+				B8A7051225B8380000E605CC /* SectionNavigationModel.swift in Sources */,
 				B82D3D9A254D2E7700F06836 /* CategoryButtonsViewModel.swift in Sources */,
 				B8093DD6251A988200D95DCF /* NotificationName+DictionaryParser.swift in Sources */,
 				B8FA93BE254BBE0D00AE362C /* NavigationLazyView.swift in Sources */,
@@ -986,6 +1009,7 @@
 				B81C86FF250A2207000B9E5F /* LibraryEntryViewModel.swift in Sources */,
 				B89CD69A2509944200D7D8ED /* MockCards.swift in Sources */,
 				B82AF5FD2548031F00FAB2A8 /* SearchBar.swift in Sources */,
+				B8A704F225B8212200E605CC /* NavigationBackChevron.swift in Sources */,
 				B8A78F0C2542F27200577974 /* DiscoverListItem.swift in Sources */,
 				B89CD6942509934700D7D8ED /* VocabularyListView.swift in Sources */,
 				B8D4569C2508D1A2000F9E5F /* SceneDelegate.swift in Sources */,

--- a/Reed/Components/NavigationBackChevron.swift
+++ b/Reed/Components/NavigationBackChevron.swift
@@ -1,0 +1,32 @@
+//
+//  NavigationBackChevron.swift
+//  Reed
+//
+//  Created by Roger Luo on 1/20/21.
+//  Copyright © 2021 Roger Luo. All rights reserved.
+//
+
+import SwiftUI
+
+struct NavigationBackChevron: View {
+    let label: String
+    let handleDismiss: () -> Void
+    
+    var body: some View { Button(action: {
+        handleDismiss()
+    }) {
+        HStack {
+            Image(systemName: "chevron.backward")
+                .imageScale(.large)
+            Text(label)
+                .font(.callout)
+                .fontWeight(.regular)
+        }
+    }}
+}
+
+struct NavigationBackChevron_Previews: PreviewProvider {
+    static var previews: some View {
+        NavigationBackChevron(label: "Back", handleDismiss: {})
+    }
+}

--- a/Reed/DiscoverTab/SearchView/views/SearchResults.swift
+++ b/Reed/DiscoverTab/SearchView/views/SearchResults.swift
@@ -14,17 +14,6 @@ struct SearchResults: View {
     @ObservedObject var viewModel: DiscoverSearchResultsViewModel
     
     @Environment(\.presentationMode) var presentationMode: Binding<PresentationMode>
-    var backButton : some View { Button(action: {
-        self.presentationMode.wrappedValue.dismiss()
-    }) {
-        HStack {
-            Image(systemName: "chevron.backward")
-                .imageScale(.large)
-            Text("Search")
-                .font(.callout)
-                .fontWeight(.regular)
-        }
-    }}
     
     var body: some View {
         ScrollView {
@@ -42,7 +31,10 @@ struct SearchResults: View {
         }
         .navigationBarTitle(viewModel.keyword, displayMode: .inline)
         .navigationBarBackButtonHidden(true)
-        .navigationBarItems(leading: backButton)
+        .navigationBarItems(leading: NavigationBackChevron(
+            label: "Search",
+            handleDismiss: { self.presentationMode.wrappedValue.dismiss() }
+        ))
     }
 }
 

--- a/Reed/Reader/models/ReaderModel.swift
+++ b/Reed/Reader/models/ReaderModel.swift
@@ -6,19 +6,55 @@
 //  Copyright © 2020 Roger Luo. All rights reserved.
 //
 
+import CoreData
 import SwiftyNarou
 
 class ReaderModel {
+    let persistentContainer: NSPersistentContainer
     let ncode: String
+    var historyEntry: HistoryEntry?
     
-    init(ncode: String) {
+    init(persistentContainer: NSPersistentContainer, ncode: String) {
+        self.persistentContainer = persistentContainer
         self.ncode = ncode
+    }
+    
+    func fetchHistoryEntry(completion: @escaping (HistoryEntry) -> Void) {
+        HistoryEntry.fetch(
+            persistentContainer: persistentContainer,
+            ncode: ncode
+        ) { historyEntryId in
+            guard let historyEntryId = historyEntryId,
+                  let historyEntry = try? self.persistentContainer.viewContext.existingObject(
+                    with: historyEntryId
+                ) as? HistoryEntry
+            else {
+                // TODO: Add novel to library before continuing?
+                fatalError("Unable to retrieve HistoryEntry.")
+            }
+            self.historyEntry = historyEntry
+            completion(historyEntry)
+        }
     }
     
     func fetchSectionData(
         sectionNcode: String,
         completion: @escaping (SectionData?) -> Void
     ) {
+        guard let historyEntry = self.historyEntry
+        else {
+            print("No history entry.")
+            return
+        }
+        
+        historyEntry.lastReadSection.id = Int(sectionNcode.components(separatedBy: "/")[1])!
+        do {
+            try persistentContainer.viewContext.save()
+        } catch {
+            print("Unable to save HistoryEntry.")
+            return
+        }
+        
         Narou.fetchSectionData(ncode: sectionNcode) { data, error in
             if error != nil {
                 print("Failed to retrieve section content due to: \(error.debugDescription)")

--- a/Reed/Reader/viewmodels/ReaderViewModel.swift
+++ b/Reed/Reader/viewmodels/ReaderViewModel.swift
@@ -25,6 +25,7 @@ struct Page: Equatable, Hashable, Identifiable {
 
 class ReaderViewModel: ObservableObject {
     let persistentContainer: NSPersistentContainer
+    let ncode: String
     let model: ReaderModel
     var historyEntry: HistoryEntry?
     var section: SectionData?
@@ -43,6 +44,7 @@ class ReaderViewModel: ObservableObject {
     
     init(persistentContainer: NSPersistentContainer, ncode: String) {
         self.persistentContainer = persistentContainer
+        self.ncode = ncode
         self.model = ReaderModel(ncode: ncode)
         
         HistoryEntry.fetch(

--- a/Reed/Reader/views/ReaderView.swift
+++ b/Reed/Reader/views/ReaderView.swift
@@ -14,9 +14,39 @@ struct ReaderView: View {
     @ObservedObject var viewModel: ReaderViewModel
     @State private var entries = [DefinitionDetails]()
     @State private var navBar: UINavigationBar?
+    @State private var isSectionNavigationPresented: Bool = false
+    
+    @Environment(\.presentationMode) var presentationMode: Binding<PresentationMode>
 
     init(ncode: String) {
         self.viewModel = ReaderViewModel(ncode: ncode)
+    }
+    
+    var sectionNavigationButton: some View {
+        Button(action: { self.isSectionNavigationPresented.toggle() }) {
+            HStack {
+                Image(systemName: "list.dash")
+                    .imageScale(.large)
+            }
+        }
+        .fullScreenCover(
+            isPresented: $isSectionNavigationPresented,
+            content: {
+                SectionNavigationView(
+                    sectionNcode: viewModel.historyEntry!.sectionNcode
+                )
+            }
+        )
+    }
+    
+    var navigationBarButtons: some View {
+        HStack {
+            NavigationBackChevron(
+                label: "",
+                handleDismiss: { self.presentationMode.wrappedValue.dismiss() }
+            )
+            sectionNavigationButton
+        }
     }
     
     var body: some View {
@@ -44,7 +74,7 @@ struct ReaderView: View {
                     }
                 )
                 .allowsDragging((viewModel.section?.prevNcode == nil || viewModel.curPage != 0)
-                                    && (viewModel.section?.nextNcode == nil || viewModel.curPage != viewModel.pages.endIndex - 1))
+                    && (viewModel.section?.nextNcode == nil || viewModel.curPage != viewModel.pages.endIndex - 1))
                 .onPageChanged { page in
                     self.viewModel.handlePageFlip(isInit: page == -1)
                 }
@@ -62,6 +92,8 @@ struct ReaderView: View {
             DefinerView(entries: $entries)
         }
         .navigationBarTitle("", displayMode: .inline)
+        .navigationBarBackButtonHidden(true)
+        .navigationBarItems(leading: navigationBarButtons)
         .introspectNavigationController { navigationController in
             self.navBar = navigationController.navigationBar
             self.navBar?.isHidden = true

--- a/Reed/Reader/views/ReaderView.swift
+++ b/Reed/Reader/views/ReaderView.swift
@@ -33,7 +33,7 @@ struct ReaderView: View {
             isPresented: $isSectionNavigationPresented,
             content: {
                 SectionNavigationView(
-                    sectionNcode: viewModel.historyEntry!.sectionNcode
+                    sectionNcode: viewModel.sectionNcode
                 )
             }
         )

--- a/Reed/Reader/views/ReaderView.swift
+++ b/Reed/Reader/views/ReaderView.swift
@@ -33,7 +33,8 @@ struct ReaderView: View {
             isPresented: $isSectionNavigationPresented,
             content: {
                 SectionNavigationView(
-                    sectionNcode: viewModel.sectionNcode
+                    sectionNcode: viewModel.sectionNcode,
+                    handleFetchSection: viewModel.fetchNextSection
                 )
             }
         )

--- a/Reed/SectionNavigation/SectionNavigationModel.swift
+++ b/Reed/SectionNavigation/SectionNavigationModel.swift
@@ -1,0 +1,24 @@
+//
+//  SectionNavigationModel.swift
+//  Reed
+//
+//  Created by Roger Luo on 1/20/21.
+//  Copyright © 2021 Roger Luo. All rights reserved.
+//
+
+import SwiftyNarou
+
+class SectionNavigationModel {
+    func fetchNovelIndex(
+        ncode: String,
+        completion: @escaping (NovelIndex?) -> Void
+    ) {
+        Narou.fetchNovelIndex(ncode: ncode) { data, error in
+            if error != nil {
+                completion(nil)
+                return
+            }
+            completion(data)
+        }
+    }
+}

--- a/Reed/SectionNavigation/SectionNavigationView.swift
+++ b/Reed/SectionNavigation/SectionNavigationView.swift
@@ -13,8 +13,14 @@ struct SectionNavigationView: View {
     @ObservedObject var viewModel: SectionNavigationViewModel
     @Environment(\.presentationMode) var presentationMode
     
-    init(sectionNcode: String) {
-        viewModel = SectionNavigationViewModel(sectionNcode: sectionNcode)
+    init(
+        sectionNcode: String,
+        handleFetchSection: @escaping (String) -> Void
+    ) {
+        viewModel = SectionNavigationViewModel(
+            sectionNcode: sectionNcode,
+            handleFetchSection: handleFetchSection
+        )
     }
     
     var dismissButton: some View {
@@ -30,11 +36,24 @@ struct SectionNavigationView: View {
                     ForEach(viewModel.chapters, id: \.self) { chapter in
                         Text(chapter.title)
                             .font(.subheadline).bold()
-                            .foregroundColor(Color(.systemGray3))
+                            .foregroundColor(.secondary)
                         VStack(alignment: .leading, spacing: 16) {
                             ForEach(chapter.sections, id: \.self) { section in
-                                Text(section.title)
-                                    .font(.body)
+                                Button(action: {
+                                    print(section.ncode, viewModel.sectionNcode)
+                                    if section.ncode != viewModel.sectionNcode {
+                                        viewModel.fetchSection(selectedSection: section.ncode)
+                                    }
+                                    self.presentationMode.wrappedValue.dismiss()
+                                }) {
+                                    Text(section.title)
+                                        .font(.body)
+                                        .foregroundColor(
+                                            section.ncode == viewModel.sectionNcode
+                                                ? Color(.systemBlue)
+                                                : .primary
+                                        )
+                                }
                             }
                         }
                     }
@@ -53,6 +72,6 @@ struct SectionNavigationView: View {
 
 struct SectionNavigationView_Previews: PreviewProvider {
     static var previews: some View {
-        SectionNavigationView(sectionNcode: "n9669bk/1")
+        SectionNavigationView(sectionNcode: "n9669bk/1", handleFetchSection: { _ in })
     }
 }

--- a/Reed/SectionNavigation/SectionNavigationView.swift
+++ b/Reed/SectionNavigation/SectionNavigationView.swift
@@ -1,0 +1,58 @@
+//
+//  SectionNavigationView.swift
+//  Reed
+//
+//  Created by Roger Luo on 1/16/21.
+//  Copyright © 2021 Roger Luo. All rights reserved.
+//
+
+import SwiftUI
+import SwiftyNarou
+
+struct SectionNavigationView: View {
+    @ObservedObject var viewModel: SectionNavigationViewModel
+    @Environment(\.presentationMode) var presentationMode
+    
+    init(sectionNcode: String) {
+        viewModel = SectionNavigationViewModel(sectionNcode: sectionNcode)
+    }
+    
+    var dismissButton: some View {
+        Button("Done") {
+            self.presentationMode.wrappedValue.dismiss()
+        }
+    }
+    
+    var body: some View {
+        NavigationView {
+            ScrollView {
+                LazyVStack(alignment: .leading, spacing: 20) {
+                    ForEach(viewModel.chapters, id: \.self) { chapter in
+                        Text(chapter.title)
+                            .font(.subheadline).bold()
+                            .foregroundColor(Color(.systemGray3))
+                        VStack(alignment: .leading, spacing: 16) {
+                            ForEach(chapter.sections, id: \.self) { section in
+                                Text(section.title)
+                                    .font(.body)
+                            }
+                        }
+                    }
+                }
+                .padding()
+            }
+            .navigationBarBackButtonHidden(true)
+            .navigationBarTitle(viewModel.novelTitle, displayMode: .inline)
+            .navigationBarItems(
+                leading: EmptyView(),
+                trailing: dismissButton
+            )
+        }
+    }
+}
+
+struct SectionNavigationView_Previews: PreviewProvider {
+    static var previews: some View {
+        SectionNavigationView(sectionNcode: "n9669bk/1")
+    }
+}

--- a/Reed/SectionNavigation/SectionNavigationViewModel.swift
+++ b/Reed/SectionNavigation/SectionNavigationViewModel.swift
@@ -1,0 +1,30 @@
+//
+//  SectionNavigationViewModel.swift
+//  Reed
+//
+//  Created by Roger Luo on 1/16/21.
+//  Copyright © 2021 Roger Luo. All rights reserved.
+//
+
+import SwiftyNarou
+
+class SectionNavigationViewModel: ObservableObject {
+    @Published var novelTitle: String = ""
+    @Published var chapters: [Chapter] = []
+    let model: SectionNavigationModel = SectionNavigationModel()
+    let novelNcode: String
+    let sectionNumber: Int
+    
+    
+    init(sectionNcode: String) {
+        let sectionNcodeParts = sectionNcode.components(separatedBy: "/")
+        self.novelNcode = sectionNcodeParts[0]
+        self.sectionNumber = Int(sectionNcodeParts[1])!
+        
+        model.fetchNovelIndex(ncode: novelNcode) { novelIndex in
+            guard let novelIndex = novelIndex else { return }
+            self.novelTitle = novelIndex.novelTitle
+            self.chapters = novelIndex.chapters
+        }
+    }
+}

--- a/Reed/SectionNavigation/SectionNavigationViewModel.swift
+++ b/Reed/SectionNavigation/SectionNavigationViewModel.swift
@@ -12,19 +12,22 @@ class SectionNavigationViewModel: ObservableObject {
     @Published var novelTitle: String = ""
     @Published var chapters: [Chapter] = []
     let model: SectionNavigationModel = SectionNavigationModel()
-    let novelNcode: String
-    let sectionNumber: Int
+    let sectionNcode: String
+    let handleFetchSection: (String) -> Void
     
-    
-    init(sectionNcode: String) {
-        let sectionNcodeParts = sectionNcode.components(separatedBy: "/")
-        self.novelNcode = sectionNcodeParts[0]
-        self.sectionNumber = Int(sectionNcodeParts[1])!
+    init(sectionNcode: String, handleFetchSection: @escaping (String) -> Void) {
+        self.sectionNcode = sectionNcode.lowercased()
+        self.handleFetchSection = handleFetchSection
         
+        let novelNcode = sectionNcode.components(separatedBy: "/")[0]
         model.fetchNovelIndex(ncode: novelNcode) { novelIndex in
             guard let novelIndex = novelIndex else { return }
             self.novelTitle = novelIndex.novelTitle
             self.chapters = novelIndex.chapters
         }
+    }
+    
+    func fetchSection(selectedSection: String) {
+        handleFetchSection(selectedSection)
     }
 }


### PR DESCRIPTION
This PR fully implements the new Section Navigation functionality, which allows a user to view all sections and chapters of a novel, and jump to any section.

Commit 1: Navigate to Section Navigation
This commit allows the user to enter SectionNavigationView from the ReaderView's navigation bar. It also builds out the basic UI for SectionNavigationView, which presents itself as a fullscreen modal.

Commit 2: Refactor HistoryEntry and fetchSection.
Lightly refactors the HistoryEntry and fetchSection code from the ReaderViewModel into the ReaderModel in order to abstract away some Core Data behavior. This refactor also allows the `fetchNextSection` code to work correctly given _any_ section, not just adjacent ones.

Commit 3: Implement Section Navigation
Implements the actual section jump feature in the SectionNavigationView. When tapping any section, the view will dismiss. If the tapped view is a different section from the current one, the tapped section will load. Otherwise, nothing will happen.

![Screen Shot 2021-02-02 at 3 55 49 AM](https://user-images.githubusercontent.com/29548429/106597444-487b0700-650b-11eb-9bdb-d323bfedb45f.png)
