### PR TITLE
hugo/{Reader, Components}: Paginator Optimization

### DIFF
--- a/Reed/Reader/views/Paginator.swift
+++ b/Reed/Reader/views/Paginator.swift
@@ -11,7 +11,7 @@ import SwiftUI
 import SwiftUIPager
 
 struct Paginator: View {
-    @ObservedObject var viewModel: PaginatorViewModel
+    @StateObject var viewModel: PaginatorViewModel
     @Binding var entries: [DefinitionDetails]
     @Binding var isNavMenuHidden: Bool
     
@@ -25,12 +25,12 @@ struct Paginator: View {
     ) {
         self._entries = entries
         self._isNavMenuHidden = isNavMenuHidden
-        self.viewModel = PaginatorViewModel(
+        self._viewModel = StateObject(wrappedValue: PaginatorViewModel(
             sectionFetcher: sectionFetcher,
             paginatorWidth: paginatorWidth,
             paginatorHeight: paginatorHeight,
             processedContentPublisher: processedContentPublisher
-        )
+        ))
     }
     
     var body: some View {
@@ -53,7 +53,6 @@ struct Paginator: View {
                 }
             }
             .tabViewStyle(PageTabViewStyle(indexDisplayMode: .never))
-            .padding(.horizontal)
             
             Text(viewModel.getPageNumberDisplay())
         }


### PR DESCRIPTION
Avoided excessive copying and substringing attributed strings in the paginate and lengthThatFits function by utilizing CFRanges and a running sum of the length of each page.

This is the amount of time it takes paginate to process 23 pages after the revisions, this is at least an order of magnitude faster.

<img width="1792" alt="Screen Shot 2021-06-14 at 9 17 33 PM" src="https://user-images.githubusercontent.com/42554019/121992486-93791680-cd56-11eb-914d-b39a455b88a9.png">

Below is an updated picture after fixing an issue where the Paginator was reloading and calling `paginate` multiple times. By changing `PaginatorViewModel` from an `@ObservedObject` to `@StateObject` Paginator now loads only once. Tested on 20 pages.
<img width="900" alt="Screen Shot 2021-06-14 at 10 41 59 PM" src="https://user-images.githubusercontent.com/42554019/121999627-65013880-cd62-11eb-9d1f-183de03fd217.png">

These changes introduce a bug where the DefinableText no longer highlights, but selections are still properly displayed in the Definer.