### PR TITLE
hugo/DefinableTextView: Fixed Highlighting

### DIFF
--- a/Reed/Components/DefinableTextView.swift
+++ b/Reed/Components/DefinableTextView.swift
@@ -14,12 +14,12 @@ private enum TextOrientation {
 }
 
 class DefinableTextView: UIView {
-    var font = UIFont(name: "Hiragino Maru Gothic ProN W4", size: 20)
     var content: NSMutableAttributedString
     var ctFrame: CTFrame?
     var linesYCoordinates: [CGFloat]?
+    let font = UIFont(name: "Hiragino Maru Gothic ProN W4", size: 20)
     private let orientation: TextOrientation
-    private let frameSetter: CTFramesetter
+    private var frameSetter: CTFramesetter
     lazy private var path: CGMutablePath = {
         let path = CGMutablePath()
         switch orientation {
@@ -37,12 +37,17 @@ class DefinableTextView: UIView {
         isVerticalOrientation: Bool = false
     ) {
         self.content = content
+        self.content.addAttributes(
+            [
+                NSAttributedString.Key.font : self.font as Any,
+                NSAttributedString.Key.foregroundColor : UIColor.label,
+                NSAttributedString.Key.verticalGlyphForm: isVerticalOrientation
+            ],
+            range: NSMakeRange(0, self.content.length)
+        )
+        frameSetter = CTFramesetterCreateWithAttributedString(content)
         self.orientation = isVerticalOrientation ? .vertical : .horizontal
 
-        self.content.addAttributes([NSAttributedString.Key.font : self.font as Any, NSAttributedString.Key.foregroundColor : UIColor.label, NSAttributedString.Key.verticalGlyphForm: isVerticalOrientation], range: NSMakeRange(0, self.content.length))
-        
-        frameSetter = CTFramesetterCreateWithAttributedString(content)
-        
         super.init(frame: frame)
     }
     
@@ -70,7 +75,7 @@ class DefinableTextView: UIView {
             context.rotate(by: .pi / 2)
             context.scaleBy(x: 1.0, y: -1.0)
         }
-
+        frameSetter = CTFramesetterCreateWithAttributedString(content)
         ctFrame = CTFramesetterCreateFrame(
             frameSetter,
             CFRangeMake(0, attributed.length),


### PR DESCRIPTION
Fixed a bug where the view did not update when user taps on a word for definition. The frameSetter needed to be reinitialized everytime the content attributes change.
![Screen Shot 2021-06-19 at 4 26 40 PM](https://user-images.githubusercontent.com/29548429/122657747-3052ff80-d11b-11eb-8684-e6659499a9d0.png)
