### PR TITLE
rawger/DefinableText: Set nav bar visibility in init.

### DIFF
--- a/Reed/Components/DefinableText/DefinableText.swift
+++ b/Reed/Components/DefinableText/DefinableText.swift
@@ -46,7 +46,7 @@ struct DefinableText: UIViewRepresentable {
         height: CGFloat,
         definerResultHandler: @escaping ([DefinitionDetails]) -> Void,
         getTokenHandler: @escaping (Int, Int, Int) -> Token?,
-        hideNavHandler: @escaping () -> Void = {}
+        toggleNavHandler: @escaping () -> Void = {}
     ) {
         self._content = content
         self.width = width
@@ -54,7 +54,7 @@ struct DefinableText: UIViewRepresentable {
         self.viewModel = DefinableTextViewModel(
             tokensRange: tokensRange,
             definerResultHandler: definerResultHandler,
-            hideNavHandler: hideNavHandler,
+            toggleNavHandler: toggleNavHandler,
             getTokenHandler: getTokenHandler
         )
     }
@@ -103,14 +103,13 @@ struct DefinableText: UIViewRepresentable {
     class Coordinator: NSObject {
         var viewModel: DefinableTextViewModel
         
-        init(
-            viewModel: DefinableTextViewModel
-        ) {
+        init(viewModel: DefinableTextViewModel) {
             self.viewModel = viewModel
         }
         
         @objc func doubleTapped() {
-            viewModel.hideNavHandler()
+            print("swag")
+            viewModel.toggleNavHandler()
         }
         
         @objc func wordTapped(gesture: UITapGestureRecognizer) {

--- a/Reed/Components/DefinableText/DefinableTextViewModel.swift
+++ b/Reed/Components/DefinableText/DefinableTextViewModel.swift
@@ -15,18 +15,18 @@ class DefinableTextViewModel: ObservableObject {
     let dictionaryFetcher = DictionaryFetcher()
     var tokensRange: [Int]
     let definerResultHandler: ([DefinitionDetails]) -> Void
-    let hideNavHandler: () -> Void
+    let toggleNavHandler: () -> Void
     let getTokenHandler: (Int, Int, Int) -> Token?
     
     internal init(
         tokensRange: [Int],
         definerResultHandler: @escaping ([DefinitionDetails]) -> Void,
-        hideNavHandler: @escaping () -> Void,
+        toggleNavHandler: @escaping () -> Void,
         getTokenHandler: @escaping (Int, Int, Int) -> Token?
     ) {
         self.tokensRange = tokensRange
         self.definerResultHandler = definerResultHandler
-        self.hideNavHandler = hideNavHandler
+        self.toggleNavHandler = toggleNavHandler
         self.getTokenHandler = getTokenHandler
     }
     

--- a/Reed/Components/DefinerView.swift
+++ b/Reed/Components/DefinerView.swift
@@ -22,15 +22,18 @@ enum DefinerConstants {
 }
 
 struct DefinerView<Content:View>: View {
+    let isNavigationBarHidden: Bool // true for custom nav bar behavior
     @Binding var entries: [DefinitionDetails]
     let content: Content
     
     init(
         entries: Binding<[DefinitionDetails]>,
+        isNavigationBarHidden: Bool,
         @ViewBuilder content: () -> Content
     ) {
-        self.content = content()
         self._entries = entries
+        self.isNavigationBarHidden = isNavigationBarHidden
+        self.content = content()
     }
     
     var body: some View {
@@ -45,7 +48,7 @@ struct DefinerView<Content:View>: View {
             .padding(.horizontal)
             .ignoresSafeArea(edges: .bottom)
             .background(Color(.systemBackground))
-            .navigationBarHidden(true)
+            .navigationBarHidden(isNavigationBarHidden)
             
             Definer(entries: $entries)
         }
@@ -54,7 +57,10 @@ struct DefinerView<Content:View>: View {
 
 struct DefinerView_Previews: PreviewProvider {
     static var previews: some View {
-        DefinerView(entries: .constant([DefinitionDetails]())) {
+        DefinerView(
+            entries: .constant([DefinitionDetails]()),
+            isNavigationBarHidden: false
+        ) {
             EmptyView()
         }
     }

--- a/Reed/NovelDetails/views/NovelDetailsView.swift
+++ b/Reed/NovelDetails/views/NovelDetailsView.swift
@@ -20,7 +20,7 @@ struct NovelDetailsView: View {
     }
     
     var body: some View {
-        DefinerView(entries: self.$entries) {
+        DefinerView(entries: self.$entries, isNavigationBarHidden: false) {
             ScrollView(.vertical, showsIndicators: false) {
                 VStack(alignment: .leading, spacing: 0) {
                     Text(viewModel.novelTitle)

--- a/Reed/Reader/views/Paginator.swift
+++ b/Reed/Reader/views/Paginator.swift
@@ -40,7 +40,7 @@ struct Paginator: View {
                         height: DefinerConstants.CONTENT_HEIGHT,
                         definerResultHandler: definerResultHandler,
                         getTokenHandler: viewModel.getToken,
-                        hideNavHandler: hideNavHandler
+                        toggleNavHandler: toggleNavHandler
                     )
                     .onAppear {
                         viewModel.handlePageFlip()
@@ -56,7 +56,7 @@ struct Paginator: View {
         self.entries = newEntries
     }
     
-    func hideNavHandler() {
+    func toggleNavHandler() {
         isNavMenuHidden.toggle()
     }
 }

--- a/Reed/Reader/views/ReaderView.swift
+++ b/Reed/Reader/views/ReaderView.swift
@@ -36,7 +36,7 @@ struct ReaderView: View {
                 isActive: $isActive
             )
 
-            DefinerView(entries: $entries) {
+            DefinerView(entries: $entries, isNavigationBarHidden: true) {
                 ZStack {
                     Paginator(
                         entries: $entries,


### PR DESCRIPTION
Adds a boolean property to DefinerView so that the previous view can decide whether the DefinerView instance should be initialized with a visible default navigation bar. This enables NovelDetails to preserve its nav bar while allowing ReaderView to use its custom navigation bar.
![Screen Shot 2021-07-08 at 7 53 11 PM](https://user-images.githubusercontent.com/29548429/125016379-217ab100-e026-11eb-8c11-5a10259483e7.png)
