### PR TITLE
Change to Definer on tap word

### DIFF
--- a/Reed/Extensions/View+addDefinerAndAppNavigator.swift
+++ b/Reed/Extensions/View+addDefinerAndAppNavigator.swift
@@ -32,7 +32,11 @@ private struct DefinerAndAppNavigator: View {
         BottomSheet(toggleDisplayMode: toggleBottomSheetDisplayMode) {
             switch bottomSheetDisplayType {
             case .navigation:
-                AppNavigator(selectedTab: $appState.selectedTab)
+                AppNavigator(
+                    selectedTab: $appState.selectedTab,
+                    bottomSheetDisplayType: $bottomSheetDisplayType,
+                    entries: $entries
+                )
             case .definer:
                 Definer(entries: $entries)
             }

--- a/Reed/Main/AppCentral/AppNavigator.swift
+++ b/Reed/Main/AppCentral/AppNavigator.swift
@@ -10,6 +10,8 @@ import SwiftUI
 
 struct AppNavigator: View {
     @Binding var selectedTab: Int
+    @Binding var bottomSheetDisplayType: BottomSheetDisplayType
+    @Binding var entries: [DefinitionDetails]
     
     var body: some View {
         HStack {
@@ -39,11 +41,18 @@ struct AppNavigator: View {
 //            )
         }
         .padding(.top)
+        .onChange(of: entries) { value in
+            bottomSheetDisplayType = .definer
+        }
     }
 }
 
 struct AppNavigator_Previews: PreviewProvider {
     static var previews: some View {
-        AppNavigator(selectedTab: .constant(0))
+        AppNavigator(
+            selectedTab: .constant(0),
+            bottomSheetDisplayType: .constant(.definer),
+            entries: .constant([])
+        )
     }
 }


### PR DESCRIPTION
Implements the functionality to reveal the Definer in the bottom sheet when tapping a word to define. This is done by having the AppNavigator watch changes to entries, and changing the bottomSheetDisplayMode when a change is detected.