### PR TITLE
rawger/{NavTabs, NovelDetails}: Clarify text

### DIFF
--- a/Reed/DiscoverTab/DiscoverView/views/DiscoverListItem.swift
+++ b/Reed/DiscoverTab/DiscoverView/views/DiscoverListItem.swift
@@ -36,7 +36,7 @@ struct DiscoverListItem: View {
                 
                 Text(viewModel.author)
                     .font(.caption)
-                    .foregroundColor(.gray)
+                    .foregroundColor(.secondary)
                     .lineLimit(1)
                     .truncationMode(.tail)
             }
@@ -48,7 +48,7 @@ struct DiscoverListItem: View {
             ) {
                 Image(systemName: "chevron.right")
                     .imageScale(.small)
-                    .foregroundColor(Color(.systemGray5))
+                    .foregroundColor(.secondary)
             }
         }
         Divider()

--- a/Reed/Main/AppCentral/AppNavigatorTab.swift
+++ b/Reed/Main/AppCentral/AppNavigatorTab.swift
@@ -57,6 +57,7 @@ struct AppNavigatorTab: View {
                     .overlay(Image(systemName: iconName).imageScale(.medium))
                 Text(self.title)
                     .font(.footnote)
+                    .foregroundColor(.primary)
             }
         }
         .buttonStyle(AppNavigatorTabButtonStyle(isSelected: selectedTab == tag))

--- a/Reed/NovelDetails/views/NovelDetailsView.swift
+++ b/Reed/NovelDetails/views/NovelDetailsView.swift
@@ -28,9 +28,11 @@ struct NovelDetailsView: View {
 
                 HStack(spacing: .zero) {
                     Text(viewModel.novelAuthor)
+                        .foregroundColor(.secondary)
                     Text("｜")
-                        .foregroundColor(.gray)
+                        .foregroundColor(.secondary)
                     Text(viewModel.novelSubgenre?.nameJp ?? "")
+                        .foregroundColor(.secondary)
                 }
                 .padding(.bottom, 16)
 
@@ -71,7 +73,7 @@ struct NovelDetailsView: View {
                 Group {
                     Text("SYNOPSIS")
                         .font(.subheadline).bold()
-                        .foregroundColor(Color(.systemGray4))
+                        .foregroundColor(.secondary)
                         .padding(.bottom, 4)
                     ZStack {
                         Rectangle()


### PR DESCRIPTION
Uses .primary and .secondary font colors to clarify text display and to make NavTab labels contrast in dark mode.
![Screen Shot 2022-01-13 at 6 12 14 PM](https://user-images.githubusercontent.com/29548429/149440309-68442a32-5d45-40d6-8b82-66d453fadacd.png)
![Screen Shot 2022-01-13 at 6 19 06 PM](https://user-images.githubusercontent.com/29548429/149440313-d9b6ed38-76d4-4b32-ab1a-ff79892177a2.png)