### PR TITLE
hugo/Reader: Made Loading Screen Opacity 0

### DIFF
--- a/Reed/Reader/views/ReaderView.swift
+++ b/Reed/Reader/views/ReaderView.swift
@@ -45,8 +45,7 @@ struct ReaderView: View {
 
                 if viewModel.isLoading {
                     Rectangle()
-                        .foregroundColor(.white)
-                        .opacity(0.5)
+                        .opacity(0)
                     ProgressView()
                         .scaleEffect(x: 2, y: 2, anchor: .center)
                 }


### PR DESCRIPTION
Made the rectangle beneath the loading screen to have an opacity of 0 to show systembackground when loading.