### PR TITLE
hugo/DiscoverSearch: Display RecommendationView when no history entries

### DIFF
--- a/Reed/DiscoverTab/DiscoverView/views/DiscoverView.swift
+++ b/Reed/DiscoverTab/DiscoverView/views/DiscoverView.swift
@@ -55,10 +55,15 @@ struct DiscoverView: View {
                 text: $searchText,
                 placement: .navigationBarDrawer(displayMode: .always)
             ) {
-                ForEach(searchViewModel.searchHistory.reversed(), id: \.self.id) { entry in
-                    Text(entry.text)
-                        .foregroundColor(Color(UIColor(.primary)))
-                        .searchCompletion(entry.text)
+                ForEach(searchViewModel.searchHistory, id: \.self.id) { entry in
+                    if entry.text == "" {
+                        Text(entry.text)
+                            .foregroundColor(Color(UIColor(.primary)))
+                    } else {
+                        Text(entry.text)
+                            .foregroundColor(Color(UIColor(.primary)))
+                            .searchCompletion(entry.text)
+                    }
                 }
             }
             .onSubmit(of: .search) {


### PR DESCRIPTION
Used placeholder SearchHistoryEntries to fill SearchHistory array in order to have the RecommendationView cover the entire screen. Placeholders cannot be tapped and do not complete the search.
![Screen Shot 2022-01-14 at 12 12 07 AM](https://user-images.githubusercontent.com/29548429/149473748-fdabb638-8491-4db7-9762-b937551fb975.png)