### PR TITLE
rawger/AppNav: Blue tab text

### DIFF
--- a/Reed/Main/AppCentral/AppNavigatorTab.swift
+++ b/Reed/Main/AppCentral/AppNavigatorTab.swift
@@ -60,7 +60,6 @@ struct AppNavigatorTab: View {
                     )
                 Text(self.title)
                     .font(.footnote)
-                    .foregroundColor(.primary)
             }
         }
         .buttonStyle(AppNavigatorTabButtonStyle(isSelected: selectedTab == tag))


### PR DESCRIPTION
Fix an issue where the selected tab's label did not turn blue.
![Screen Shot 2022-01-14 at 12 11 04 AM](https://user-images.githubusercontent.com/29548429/149473576-501180bb-863c-43de-88ef-ca2842a155d0.png)