### PR TITLE
rawger/DiscoverView: Fix double load on infinite scroll

### DIFF
--- a/Reed/DiscoverTab/DiscoverView/viewmodels/DiscoverViewModel.swift
+++ b/Reed/DiscoverTab/DiscoverView/viewmodels/DiscoverViewModel.swift
@@ -33,7 +33,6 @@ class DiscoverViewModel: ObservableObject {
     @Published var rows: [DiscoverListItemViewModel] = []
     @Published var category: DiscoverListCategory = .recent
     var startIndex: Int = -FetchNarouConstants.LOAD_INCREMENT.rawValue
-    var resultCount: Int = 0
     
     init() {
         updateRows()
@@ -44,14 +43,11 @@ class DiscoverViewModel: ObservableObject {
         Narou.fetchNarouApi(request: request) { data, error in
             if error != nil { return }
             if let data = data {
-                self.resultCount = min(
-                    data.0,
-                    FetchNarouConstants.MAX_RESULT_INDEX.rawValue
-                )
                 for entry in data.1 {
                     self.rows.append(DiscoverListItemViewModel(from: entry))
                 }
             }
+            print(self.startIndex)
         }
     }
     
@@ -66,7 +62,9 @@ class DiscoverViewModel: ObservableObject {
         }
         
         let increment = FetchNarouConstants.LOAD_INCREMENT.rawValue
-        if startIndex + increment > resultCount { return nil }
+        if startIndex + increment > FetchNarouConstants.MAX_RESULT_INDEX.rawValue {
+            return nil
+        }
         
         startIndex += increment
         return NarouRequest(
@@ -90,7 +88,6 @@ class DiscoverViewModel: ObservableObject {
     private func resetData() {
         rows = []
         startIndex = -FetchNarouConstants.LOAD_INCREMENT.rawValue
-        resultCount = 0
         updateRows()
     }
 }

--- a/Reed/DiscoverTab/DiscoverView/views/DiscoverList.swift
+++ b/Reed/DiscoverTab/DiscoverView/views/DiscoverList.swift
@@ -24,7 +24,7 @@ struct DiscoverList: View {
                     lastSelectedDefinableTextView: $lastSelectedDefinableTextView,
                     definerResultHandler: definerResultHandler
                 )
-                    .onAppear {
+                    .task {
                         if row == self.rows.last {
                             self.updateRows()
                         }

--- a/Reed/DiscoverTab/DiscoverView/views/DiscoverView.swift
+++ b/Reed/DiscoverTab/DiscoverView/views/DiscoverView.swift
@@ -19,7 +19,7 @@ struct DiscoverView: View {
     
     var body: some View {
         NavigationView {
-            ScrollView(showsIndicators: false) {
+            ScrollView(showsIndicators: true) {
                 VStack(alignment: .center) {
                     CategoryButtons(
                         activeCategory: $viewModel.category,

--- a/Reed/DiscoverTab/SearchView/viewmodels/DiscoverSearchViewModel.swift
+++ b/Reed/DiscoverTab/SearchView/viewmodels/DiscoverSearchViewModel.swift
@@ -24,6 +24,7 @@ class DiscoverSearchViewModel: ObservableObject {
     lazy var decoder: JSONDecoder = { JSONDecoder() }()
     
     init() {
+        clearSearchHistory()
         getSearchHistory()
     }
 }


### PR DESCRIPTION
Fixes an issue where scrolling down too fast would cause the view to load more data twice. Also cleans up some DiscoverViewModel logic.