### PR TITLE
rawger/BottomSheet: Fix teleporting, deprecation warning.

### DIFF
--- a/Reed/Components/BottomSheet.swift
+++ b/Reed/Components/BottomSheet.swift
@@ -56,7 +56,13 @@ struct BottomSheet<Content: View>: View {
             .shadow(radius: DefinerConstants.BOTTOM_SHEET_SHADOW_RADIUS)
             .frame(height: geometry.size.height, alignment: .bottom)
             .offset(y: max(self.offset + self.translation, 0))
-            .animation(.interactiveSpring(response: 0.25, dampingFraction: 0.75))
+            .animation(
+                .interactiveSpring(
+                    response: 0.25,
+                    dampingFraction: 0.50
+                ),
+                value: self.translation
+            )
             .gesture(
                 DragGesture().updating(self.$translation) { value, state, _ in
                     state = value.translation.height


### PR DESCRIPTION
Addresses a deprecation warning with .animation, which also fixes an issue where the bottom sheet teleports the first time the tab changes.