### PR TITLE
rawger/AppCentral: Fix phantom tab view

### DIFF
--- a/Reed/Components/NovelList/NovelListRow.swift
+++ b/Reed/Components/NovelList/NovelListRow.swift
@@ -70,7 +70,6 @@ struct NovelListRow: View {
                     
                     NavigationLinkRightChevron {
                         pushedView()
-                        
                     }
                     .padding(.top, 4)
                 }

--- a/Reed/Main/AppCentral/AppCentral.swift
+++ b/Reed/Main/AppCentral/AppCentral.swift
@@ -28,19 +28,21 @@ struct AppCentral: View {
         TabView(selection: $appState.selectedTab) {
             LibraryView(switchToDiscover: appState.switchToDiscover)
                 .tag(0)
+                .introspectTabBarController { tabBarController in
+                    tabBarController.tabBar.isHidden = true
+                }
             
             DiscoverView()
                 .tag(1)
+                .introspectTabBarController { tabBarController in
+                    tabBarController.tabBar.isHidden = true
+                }
             
 //            VocabularyListView()
 //              .tag(2)
 //
 //            SettingsView()
 //              .tag(3)
-        }
-        .ignoresSafeArea(edges: .bottom)
-        .introspectTabBarController { tabBarController in
-            tabBarController.tabBar.isHidden = true
         }
         .environmentObject(appState)
     }


### PR DESCRIPTION
Fixes an issue where the tab view will appear when the content of the screen touches the tab view for certain views, and only on an actual device. We fix this by using introspect to hide the tab view per tab, as opposed to hiding it for the entirety of the tab view.