### PR TITLE
hugo/WKText: Decrease debounce threshold

### DIFF
--- a/Reed/Components/WKText/AddClickHandlers.js
+++ b/Reed/Components/WKText/AddClickHandlers.js
@@ -53,7 +53,7 @@ const onTapWord = token => {
                 token.classList.add('highlighted');
                 lastSelectedToken = token;
             }
-        }, 250);
+        }, 150);
     };
 };
 


### PR DESCRIPTION
Reduce the double tap debounce threshold to make WKText highlighting feel more responsive.