### PR TITLE
Switch order of cutom highlight and built in draw

### DIFF
--- a/Reed/Components/DefinableText/DefinableTextView.swift
+++ b/Reed/Components/DefinableText/DefinableTextView.swift
@@ -140,8 +140,6 @@ class DefinableTextView: UIView {
             context.rotate(by: .pi / 2)
             context.scaleBy(x: 1.0, y: -1.0)
         }
-        CTFrameDraw(ctFrame!, context)
-        
         let lines = CTFrameGetLines(ctFrame!) as! [CTLine]
         var lineOrigins = Array<CGPoint>(repeating: CGPoint.zero, count: lines.count)
         CTFrameGetLineOrigins(ctFrame!, CFRange(location: 0, length: lines.count), &lineOrigins)
@@ -175,6 +173,8 @@ class DefinableTextView: UIView {
             yCoordinates.append(bounds.height - lineOrigins[lineIndex].y)
         }
         linesYCoordinates = yCoordinates
+        
+        CTFrameDraw(ctFrame!, context)
     }
 }
 


### PR DESCRIPTION
Fixed an issue where the highlight is drawn after the text, therefore changing the text color. Switched the order so that highlight is drawn below the text. This is doable because the selected content is attached with a clear background color, so when it is drawn on top of the yellow highlight, it does not obstruct it.