### PR TITLE
Highlight overlay and last selected view fix

### DIFF
--- a/Reed/Components/DefinableText/DefinableTextView.swift
+++ b/Reed/Components/DefinableText/DefinableTextView.swift
@@ -140,8 +140,6 @@ class DefinableTextView: UIView {
             context.rotate(by: .pi / 2)
             context.scaleBy(x: 1.0, y: -1.0)
         }
-        CTFrameDraw(ctFrame!, context)
-        
         let lines = CTFrameGetLines(ctFrame!) as! [CTLine]
         var lineOrigins = Array<CGPoint>(repeating: CGPoint.zero, count: lines.count)
         CTFrameGetLineOrigins(ctFrame!, CFRange(location: 0, length: lines.count), &lineOrigins)
@@ -175,6 +173,8 @@ class DefinableTextView: UIView {
             yCoordinates.append(bounds.height - lineOrigins[lineIndex].y)
         }
         linesYCoordinates = yCoordinates
+        
+        CTFrameDraw(ctFrame!, context)
     }
 }
 

--- a/Reed/Components/NovelList/NovelList.swift
+++ b/Reed/Components/NovelList/NovelList.swift
@@ -9,8 +9,8 @@
 import SwiftUI
 
 struct NovelList: View {
+    @State private var lastSelectedDefinableTextView: DefinableTextView?
     @Binding var rowData: [NovelListRowData]
-    @Binding var lastSelectedDefinableTextView: DefinableTextView?
     let definerResultHandler: ([DefinitionDetails]) -> Void
     let updateRows: () -> Void
     let pushedViewType: PushedViewType
@@ -47,7 +47,7 @@ struct NovelList: View {
                     if new.id == old.id {
                         new.content.addAttribute(
                             NSAttributedString.Key.backgroundColor,
-                            value: UIColor.systemYellow.withAlphaComponent(0.3),
+                            value: UIColor.clear,
                             range: old.selectedRange!
                         )
                         new.selectedRange = old.selectedRange

--- a/Reed/DiscoverTab/DiscoverView/views/DiscoverView.swift
+++ b/Reed/DiscoverTab/DiscoverView/views/DiscoverView.swift
@@ -13,7 +13,6 @@ struct DiscoverView: View {
     @StateObject var definerResults: DefinerResults = DefinerResults()
     @StateObject var viewModel = DiscoverViewModel()
     @StateObject var searchViewModel = DiscoverSearchViewModel()
-    @State private var lastSelectedDefinableTextView: DefinableTextView?
     @State private var searchText: String = ""
     @State private var pushSearchResults: Bool = false
     
@@ -35,7 +34,6 @@ struct DiscoverView: View {
                         }
                         NovelList(
                             rowData: $viewModel.rows,
-                            lastSelectedDefinableTextView: $lastSelectedDefinableTextView,
                             definerResultHandler: definerResults.updateEntries(entries:),
                             updateRows: viewModel.updateRows,
                             pushedViewType: .NovelDetails
@@ -43,8 +41,7 @@ struct DiscoverView: View {
                         
                         NavigationLink(
                             destination: SearchResults(
-                                searchText: searchText,
-                                lastSelectedDefinableTextView: $lastSelectedDefinableTextView
+                                searchText: searchText
                             ),
                             isActive: $pushSearchResults
                         ) {

--- a/Reed/DiscoverTab/SearchView/views/SearchResults.swift
+++ b/Reed/DiscoverTab/SearchView/views/SearchResults.swift
@@ -14,14 +14,11 @@ import WebKit
 struct SearchResults: View {
     @StateObject private var definerResults: DefinerResults = DefinerResults()
     @StateObject var viewModel: DiscoverSearchResultsViewModel
-    @Binding var lastSelectedDefinableTextView: DefinableTextView?
     
     init(
-        searchText: String,
-        lastSelectedDefinableTextView: Binding<DefinableTextView?>
+        searchText: String
     ) {
         self._viewModel = StateObject(wrappedValue: DiscoverSearchResultsViewModel(searchText: searchText))
-        self._lastSelectedDefinableTextView = lastSelectedDefinableTextView
     }
     
     var body: some View {
@@ -29,7 +26,6 @@ struct SearchResults: View {
             ScrollView {
                 NovelList(
                     rowData: $viewModel.searchResults,
-                    lastSelectedDefinableTextView: $lastSelectedDefinableTextView,
                     definerResultHandler: definerResults.updateEntries(entries:),
                     updateRows: viewModel.updateSearchResults,
                     pushedViewType: .NovelDetails
@@ -47,8 +43,7 @@ struct SearchResults: View {
 struct SearchResults_Previews: PreviewProvider {
     static var previews: some View {
         SearchResults(
-            searchText: "無職転生",
-            lastSelectedDefinableTextView: .constant(DefinableTextView(coder: NSCoder()))
+            searchText: "無職転生"
         )
     }
 }

--- a/Reed/LibraryTab/views/LibraryView.swift
+++ b/Reed/LibraryTab/views/LibraryView.swift
@@ -11,7 +11,6 @@ import SwiftUI
 struct LibraryView: View {
     @StateObject private var definerResults = DefinerResults()
     @StateObject private var viewModel: LibraryViewModel = LibraryViewModel()
-    @State private var lastSelectedDefinableTextView: DefinableTextView?
     let switchToDiscover: () -> Void
 
     var body: some View {
@@ -19,7 +18,6 @@ struct LibraryView: View {
             ScrollView {
                 NovelList(
                     rowData: $viewModel.libraryEntryData,
-                    lastSelectedDefinableTextView: $lastSelectedDefinableTextView,
                     definerResultHandler: definerResults.updateEntries(entries:),
                     updateRows: {},
                     pushedViewType: .Reader


### PR DESCRIPTION
Fixed an issue where the highlight from NSAttribute will show up when user scroll past a view and scroll back to reload it. Fixed a small bug where the Discover and SearchResult share the same lastSelectedDefinableTextView.